### PR TITLE
Add Jackett integration and indexer selection

### DIFF
--- a/apps/web/src/trackers.tsx
+++ b/apps/web/src/trackers.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { listTrackers, createTracker, updateTracker, deleteTracker, testTracker } from "./api";
+import {
+  listTrackers,
+  createTracker,
+  updateTracker,
+  deleteTracker,
+  testTracker,
+  fetchJackettDefault,
+  fetchJackettIndexers,
+} from "./api";
 
 export function Trackers({ token }: { token: string }) {
   const [items, setItems] = useState<any[]>([]);
@@ -58,6 +66,25 @@ export function Trackers({ token }: { token: string }) {
     } catch (e: any) {
       alert(e.message || String(e));
     }
+  }
+
+  async function fetchFromJackett() {
+    try {
+      const def = await fetchJackettDefault(token);
+      setJackettBase(def.base_url);
+      setJackettId(def.api_key);
+      const idx = await fetchJackettIndexers(token);
+      setJackettIndexers(idx || []);
+    } catch (e: any) {
+      alert(e.message || String(e));
+    }
+  }
+
+  function onJackettIndexer(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    setJackettSel(value);
+    const found = jackettIndexers.find(it => it.name === value);
+    if (found) setJackettId(found.id);
   }
 
   return (


### PR DESCRIPTION
## Summary
- wire up tracker screen to fetch default Jackett settings and list available indexers
- allow selecting a Jackett indexer to auto-fill the tracker id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c730e9c7e8832991329839caad68e4