### PR TITLE
Ensure Jackett discovery auth headers are used during discovery

### DIFF
--- a/apps/api/app/services/jackett_adapter.py
+++ b/apps/api/app/services/jackett_adapter.py
@@ -35,12 +35,6 @@ class JackettAdapter:
             return {}
         return {"apikey": self.api_key}
 
-    def _auth_params(self) -> Dict[str, str]:
-        params: Dict[str, str] = {}
-        if JACKETT_API_KEY:
-            params["apikey"] = JACKETT_API_KEY
-        return params
-
     # ------------ discovery ------------
     def _read_catalog(self) -> List[Dict[str, Any]]:
         try:
@@ -63,12 +57,15 @@ class JackettAdapter:
         GET /api/v2.0/indexers returns either rich objects or minimal list.
         We normalize into: slug, name, configured, needs
         """
-        url = f"{self.base}/api/v2.0/indexers/
+        url = f"{self.base}/api/v2.0/indexers/"
         params = self._auth_params()
+        headers = self._auth_headers()
         try:
             kwargs = {"timeout": 10, "follow_redirects": True}
             if params:
                 kwargs["params"] = params
+            if headers:
+                kwargs["headers"] = headers
             r = httpx.get(url, **kwargs)
             self._ensure_no_redirect(r, url, "fetching indexers")
             r.raise_for_status()
@@ -85,9 +82,12 @@ class JackettAdapter:
     def _get_schema(self, slug: str) -> Dict[str, Any]:
         url = f"{self.base}/api/v2.0/indexers/{slug}/schema/"
         params = self._auth_params()
+        headers = self._auth_headers()
         kwargs = {"timeout": 10, "follow_redirects": True}
         if params:
             kwargs["params"] = params
+        if headers:
+            kwargs["headers"] = headers
         r = httpx.get(url, **kwargs)
         self._ensure_no_redirect(r, url, f"fetching schema for '{slug}'")
         r.raise_for_status()

--- a/apps/api/tests/test_jackett_adapter.py
+++ b/apps/api/tests/test_jackett_adapter.py
@@ -1,0 +1,44 @@
+import httpx
+from typing import Dict
+
+from app.services import jackett_adapter
+
+
+def _capture_get(monkeypatch, payload):
+    seen: Dict[str, object] = {}
+
+    def fake_get(url: str, **kwargs):
+        seen["url"] = url
+        seen["params"] = kwargs.get("params")
+        seen["headers"] = kwargs.get("headers")
+        request = httpx.Request(
+            "GET",
+            url,
+            params=kwargs.get("params"),
+            headers=kwargs.get("headers"),
+        )
+        return httpx.Response(200, request=request, json=payload)
+
+    monkeypatch.setattr(jackett_adapter.httpx, "get", fake_get)
+    return seen
+
+
+def test_fetch_indexers_uses_auth_headers(monkeypatch):
+    seen = _capture_get(monkeypatch, payload=[])
+    monkeypatch.setattr(jackett_adapter, "JACKETT_API_KEY", "secret")
+    adapter = jackett_adapter.JackettAdapter()
+
+    assert adapter._fetch_indexers() == []
+    assert seen["params"] == {"apikey": "secret"}
+    assert seen["headers"] == {"X-Api-Key": "secret"}
+
+
+def test_get_schema_uses_auth_headers(monkeypatch):
+    seen = _capture_get(monkeypatch, payload={"fields": []})
+    monkeypatch.setattr(jackett_adapter, "JACKETT_API_KEY", "secret")
+    adapter = jackett_adapter.JackettAdapter()
+
+    assert adapter._get_schema("slug") == {"fields": []}
+    assert seen["params"] == {"apikey": "secret"}
+    assert seen["headers"] == {"X-Api-Key": "secret"}
+


### PR DESCRIPTION
## Summary
- ensure Jackett discovery requests include Jackett API key headers in addition to query params
- add unit tests that verify the API key is sent on indexer and schema discovery calls

## Testing
- pytest apps/api/tests/test_jackett_adapter.py
- pytest apps/api/tests/test_trackers.py

------
https://chatgpt.com/codex/tasks/task_e_68c9aac3432c832983bba635e46a98ef