### PR TITLE
Add web download controls and API helpers

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -54,3 +54,32 @@ export async function createDownload(body: {
   const { data } = await http.post(joinUrl(API_BASE, "/downloads"), payload);
   return data;
 }
+
+export async function pauseDownload(id: string) {
+  const { data } = await http.post(
+    joinUrl(API_BASE, `/downloads/${encodeURIComponent(id)}/pause`),
+    {}
+  );
+  return data;
+}
+
+export async function resumeDownload(id: string) {
+  const { data } = await http.post(
+    joinUrl(API_BASE, `/downloads/${encodeURIComponent(id)}/resume`),
+    {}
+  );
+  return data;
+}
+
+export async function deleteDownload(
+  id: string,
+  options: { withFiles?: boolean } = {}
+) {
+  const baseUrl = joinUrl(API_BASE, `/downloads/${encodeURIComponent(id)}`);
+  const url =
+    typeof options.withFiles === "boolean"
+      ? `${baseUrl}?withFiles=${options.withFiles ? "true" : "false"}`
+      : baseUrl;
+  const { data } = await http.delete(url);
+  return data;
+}


### PR DESCRIPTION
## Summary
- add API wrappers to pause, resume, and delete downloads via the FastAPI endpoints
- replace the downloads table placeholder with Pause/Stop/Delete actions and a confirmation modal for deletions
- surface action errors to users and refresh the list after successful operations

## Testing
- npm run build