### PR TITLE
feat: add metadata enrichment pipeline and UI

### DIFF
--- a/apps/api/app/api/v1/endpoints/meta.py
+++ b/apps/api/app/api/v1/endpoints/meta.py
@@ -1,0 +1,49 @@
+"""Metadata lookup endpoints for the web UI."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from app.core.config import settings
+from app.schemas.media import Classification
+from app.services.metadata import get_classifier, get_metadata_router
+
+
+router = APIRouter(prefix="/meta", tags=["metadata"])
+
+
+class LookupRequest(BaseModel):
+    title: str = Field(..., min_length=1)
+    hint: Literal["music", "movie", "tv", "other", "auto"] = "auto"
+
+
+@router.post("/lookup")
+async def lookup(body: LookupRequest) -> dict[str, Any]:
+    classifier = get_classifier()
+    router_service = get_metadata_router()
+
+    if body.hint == "auto":
+        classification = classifier.classify_torrent(body.title)
+    else:
+        classification = Classification(
+            type=body.hint if body.hint != "auto" else "other",
+            confidence=0.99,
+            reasons=[f"hint:{body.hint}"],
+        )
+    card = await router_service.enrich(classification, body.title)
+    return card.model_dump()
+
+
+@router.get("/providers/status")
+def providers_status() -> dict[str, Any]:
+    return {
+        "tmdb": bool(settings.TMDB_API_KEY),
+        "omdb": bool(settings.OMDB_API_KEY),
+        "discogs": bool(settings.DISCOGS_TOKEN),
+        "lastfm": bool(settings.LASTFM_API_KEY),
+        "musicbrainz": bool(settings.MB_USER_AGENT),
+    }
+

--- a/apps/api/app/api/v1/endpoints/search.py
+++ b/apps/api/app/api/v1/endpoints/search.py
@@ -1,0 +1,29 @@
+"""Search endpoint returning classified + enriched Jackett results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from app.services.jackett_adapter import JackettAdapter
+
+
+router = APIRouter(prefix="/search", tags=["metadata-search"])
+
+
+def get_adapter() -> JackettAdapter:
+    return JackettAdapter()
+
+
+@router.get("")
+async def search(
+    q: str = Query(..., min_length=2, alias="q"),
+    limit: int = Query(40, ge=1, le=100),
+    adapter: JackettAdapter = Depends(get_adapter),
+) -> dict[str, Any]:
+    cards, meta = await adapter.search_with_metadata(q, limit=limit)
+    payload: dict[str, Any] = {"items": [card.model_dump() for card in cards]}
+    payload.update(meta)
+    return payload
+

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,7 +7,9 @@ import redis.asyncio as redis
 
 from app.core.config import settings
 from app.db.init_db import init_db
-from app.routers import health, auth, downloads, search, trackers
+from app.routers import health, auth, downloads, trackers
+from app.api.v1.endpoints import meta as meta_endpoints
+from app.api.v1.endpoints import search as metadata_search
 from app.services.search.jackett_bootstrap import ensure_jackett_tracker
 from app.services.bt.qbittorrent import health_check as qb_health_check
 
@@ -26,8 +28,9 @@ app.add_middleware(
 app.include_router(health.router, prefix="/api/v1")
 app.include_router(auth.router, prefix="/api/v1")
 app.include_router(downloads.router, prefix="/api/v1")
-app.include_router(search.router, prefix="/api/v1")
 app.include_router(trackers.router, prefix="/api/v1")
+app.include_router(metadata_search.router, prefix="/api/v1")
+app.include_router(meta_endpoints.router, prefix="/api/v1")
 
 @app.on_event("startup")
 async def startup_event():

--- a/apps/api/app/schemas/media.py
+++ b/apps/api/app/schemas/media.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for metadata classification and enrichment."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Classification(BaseModel):
+    """Result of applying metadata heuristics to a torrent title."""
+
+    type: Literal["music", "movie", "tv", "other"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class EnrichedProvider(BaseModel):
+    """Details about a metadata provider participating in enrichment."""
+
+    name: str
+    used: bool = False
+    extra: dict | None = None
+
+
+class EnrichedCard(BaseModel):
+    """Unified representation of a classified + enriched media item."""
+
+    media_type: Literal["music", "movie", "tv", "other"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    title: str
+    parsed: dict | None = None
+    ids: dict = Field(default_factory=dict)
+    details: dict = Field(default_factory=dict)
+    providers: list[EnrichedProvider] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+    needs_confirmation: bool = False
+

--- a/apps/api/app/services/metadata/__init__.py
+++ b/apps/api/app/services/metadata/__init__.py
@@ -1,0 +1,37 @@
+"""Factory helpers for metadata classification and enrichment."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.core.config import settings
+
+from .classifier import Classifier
+from .router import MetadataRouter
+from .providers.tmdb import TMDBClient
+from .providers.omdb import OMDbClient
+from .providers.musicbrainz import MusicBrainzClient
+from .providers.discogs import DiscogsClient
+from .providers.lastfm import LastFMClient
+
+
+@lru_cache
+def get_classifier() -> Classifier:
+    return Classifier()
+
+
+@lru_cache
+def get_metadata_router() -> MetadataRouter:
+    tmdb_client = TMDBClient(api_key=settings.TMDB_API_KEY)
+    omdb_client = OMDbClient(api_key=settings.OMDB_API_KEY)
+    mb_client = MusicBrainzClient(user_agent=settings.MB_USER_AGENT)
+    discogs_client = DiscogsClient(token=settings.DISCOGS_TOKEN)
+    lastfm_client = LastFMClient(api_key=settings.LASTFM_API_KEY)
+    return MetadataRouter(
+        tmdb_client=tmdb_client,
+        omdb_client=omdb_client,
+        musicbrainz_client=mb_client,
+        discogs_client=discogs_client,
+        lastfm_client=lastfm_client,
+    )
+

--- a/apps/api/app/services/metadata/classifier.py
+++ b/apps/api/app/services/metadata/classifier.py
@@ -1,0 +1,155 @@
+"""Deterministic torrent classifier using lightweight heuristics."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Dict, Iterable, Literal, Optional
+
+from app.schemas.media import Classification
+
+MediaType = Literal["music", "movie", "tv", "other"]
+
+
+class Classifier:
+    """Apply heuristic scoring to Torznab/Jackett search results.
+
+    The classifier is intentionally deterministic and explainable.  Each
+    heuristic contributes a weighted vote to one of the supported media
+    types.  The final classification is selected via argmax with the
+    reported confidence derived from the weight distribution.
+    """
+
+    category_weights: Dict[str, tuple[MediaType, float]]
+    indexer_priors: Dict[str, tuple[MediaType, float]]
+    threshold_low: float
+
+    music_tokens: Iterable[tuple[re.Pattern[str], float, str]]
+    tv_tokens: Iterable[tuple[re.Pattern[str], float, str]]
+    movie_tokens: Iterable[tuple[re.Pattern[str], float, str]]
+
+    def __init__(self, threshold_low: float = 0.55) -> None:
+        self.threshold_low = threshold_low
+        # Common Torznab category labels.  Mapping is substring based so
+        # we normalise to lowercase before matching.
+        self.category_weights = {
+            "movies": ("movie", 0.9),
+            "movie": ("movie", 0.9),
+            "films": ("movie", 0.9),
+            "tv": ("tv", 0.9),
+            "television": ("tv", 0.9),
+            "series": ("tv", 0.6),
+            "audio": ("music", 0.9),
+            "music": ("music", 0.9),
+            "mp3": ("music", 0.8),
+            "flac": ("music", 0.8),
+        }
+
+        # Prior knowledge about popular music indexers helps the model
+        # converge quickly even when the torrent title is ambiguous.
+        self.indexer_priors = {
+            "redacted": ("music", 0.95),
+            "orpheus": ("music", 0.95),
+            "broadcasthenet": ("tv", 0.75),
+        }
+
+        self.music_tokens = [
+            (re.compile(r"\bFLAC\b", re.I), 0.5, "FLAC token"),
+            (re.compile(r"\bAPE\b", re.I), 0.5, "APE token"),
+            (re.compile(r"\bALAC\b", re.I), 0.5, "ALAC token"),
+            (re.compile(r"\bMP3\b", re.I), 0.45, "MP3 token"),
+            (re.compile(r"\bV(?:0|2)\b", re.I), 0.4, "VBR token"),
+            (re.compile(r"\b320kbps\b", re.I), 0.45, "320kbps token"),
+            (re.compile(r"\bVinyl\b", re.I), 0.45, "Vinyl token"),
+            (re.compile(r"\bSACD\b", re.I), 0.5, "SACD token"),
+            (re.compile(r"\b24bit\b", re.I), 0.45, "24bit token"),
+            (re.compile(r"\b16bit\b", re.I), 0.3, "16bit token"),
+            (re.compile(r"\bCUE\b", re.I), 0.3, "CUE token"),
+            (re.compile(r"\bLOG\b", re.I), 0.3, "LOG token"),
+            (
+                re.compile(r"^[\w .'-]+ - [\w .'-]+ \((19|20)\d{2}\)", re.I),
+                0.55,
+                "Artist - Album pattern",
+            ),
+        ]
+
+        self.tv_tokens = [
+            (re.compile(r"S\d{1,2}E\d{1,2}", re.I), 0.45, "SxxEyy pattern"),
+            (re.compile(r"Season\s+\d+", re.I), 0.4, "Season pattern"),
+            (re.compile(r"Episode\s+\d+", re.I), 0.35, "Episode pattern"),
+            (re.compile(r"E\d{2}\b", re.I), 0.25, "Episode shorthand"),
+            (re.compile(r"Complete Series", re.I), 0.4, "Complete series"),
+        ]
+
+        self.movie_tokens = [
+            (re.compile(r"(19|20)\d{2}"), 0.3, "Year token"),
+            (re.compile(r"\b2160p\b", re.I), 0.35, "2160p token"),
+            (re.compile(r"\b1080p\b", re.I), 0.3, "1080p token"),
+            (re.compile(r"\b720p\b", re.I), 0.25, "720p token"),
+            (re.compile(r"x264", re.I), 0.3, "x264 token"),
+            (re.compile(r"x265", re.I), 0.3, "x265 token"),
+            (re.compile(r"HEVC", re.I), 0.3, "HEVC token"),
+            (re.compile(r"BluRay", re.I), 0.3, "BluRay token"),
+            (re.compile(r"WEB[- ]?DL", re.I), 0.3, "WEB-DL token"),
+            (re.compile(r"REMUX", re.I), 0.35, "REMUX token"),
+            (re.compile(r"HDR\b", re.I), 0.25, "HDR token"),
+            (re.compile(r"\bDV\b", re.I), 0.25, "Dolby Vision token"),
+        ]
+
+    def classify_torrent(
+        self,
+        title: str,
+        jackett_category_desc: Optional[str] = None,
+        indexer_name: Optional[str] = None,
+    ) -> Classification:
+        """Return a :class:`Classification` for the provided torrent."""
+
+        normalized_title = title or ""
+        category = (jackett_category_desc or "").lower()
+        indexer = (indexer_name or "").lower()
+
+        scores: Dict[MediaType, float] = defaultdict(float)
+        total_weight = 0.0
+        reasons: list[str] = []
+
+        # Category signals
+        for needle, (media_type, weight) in self.category_weights.items():
+            if needle in category:
+                scores[media_type] += weight
+                total_weight += weight
+                reasons.append(f"category:{needle}")
+
+        # Indexer priors
+        if indexer and indexer in self.indexer_priors:
+            media_type, weight = self.indexer_priors[indexer]
+            scores[media_type] += weight
+            total_weight += weight
+            reasons.append(f"indexer_prior:{indexer}")
+
+        def _apply(patterns: Iterable[tuple[re.Pattern[str], float, str]], media_type: MediaType) -> None:
+            nonlocal total_weight
+            for regex, weight, label in patterns:
+                if regex.search(normalized_title):
+                    scores[media_type] += weight
+                    total_weight += weight
+                    reasons.append(f"title:{label}")
+
+        _apply(self.music_tokens, "music")
+        _apply(self.tv_tokens, "tv")
+        _apply(self.movie_tokens, "movie")
+
+        if total_weight <= 0.0:
+            reasons.append("no_signals")
+            return Classification(type="other", confidence=0.0, reasons=reasons)
+
+        # Pick the best scoring type; use deterministic order for ties.
+        ordering = ["music", "movie", "tv", "other"]
+        best_media = max(ordering, key=lambda m: (scores[m], -ordering.index(m)))
+        best_score = scores[best_media]
+        confidence = best_score / total_weight if total_weight else 0.0
+
+        return Classification(type=best_media, confidence=min(confidence, 1.0), reasons=reasons)
+
+
+__all__ = ["Classifier"]
+

--- a/apps/api/app/services/metadata/providers/discogs.py
+++ b/apps/api/app/services/metadata/providers/discogs.py
@@ -1,0 +1,83 @@
+"""Discogs metadata provider (master/release search)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class DiscogsClient:
+    base_url = "https://api.discogs.com"
+
+    def __init__(self, token: str | None, timeout: float = 8.0) -> None:
+        self.token = token
+        self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"User-Agent": "Phelia/0.1 (Discogs metadata)"}
+        if self.token:
+            headers["Authorization"] = f"Discogs token={self.token}"
+        return headers
+
+    async def lookup_release(
+        self,
+        artist: str | None,
+        album: str,
+        year: int | None = None,
+        mb_release_group_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        if not self.token:
+            logger.debug("discogs: missing token, skipping lookup")
+            return None
+        params = {"type": "master", "per_page": 5}
+        if artist:
+            params["artist"] = artist
+        if album:
+            params["release_title"] = album
+        if year:
+            params["year"] = year
+        if mb_release_group_id:
+            params["mbid"] = mb_release_group_id
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(f"{self.base_url}/database/search", params=params, headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("discogs http error album=%s status=%s", album, exc.response.status_code)
+            return None
+        except httpx.RequestError as exc:
+            logger.warning("discogs request error album=%s error=%s", album, exc)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+        results = data.get("results") or []
+        if not results:
+            return None
+        best = results[0]
+        formats = best.get("format") or best.get("formats") or []
+        if isinstance(formats, list):
+            format_names = [f.get("name") if isinstance(f, dict) else f for f in formats]
+        else:
+            format_names = [str(formats)]
+        return {
+            "id": best.get("id"),
+            "title": best.get("title"),
+            "year": best.get("year"),
+            "label": (best.get("label") or [None])[0] if isinstance(best.get("label"), list) else best.get("label"),
+            "catalog_number": best.get("catno"),
+            "thumb": best.get("thumb"),
+            "cover_image": best.get("cover_image"),
+            "formats": [f for f in format_names if f],
+            "extra": best,
+        }
+
+
+__all__ = ["DiscogsClient"]
+

--- a/apps/api/app/services/metadata/providers/lastfm.py
+++ b/apps/api/app/services/metadata/providers/lastfm.py
@@ -1,0 +1,76 @@
+"""Client for Last.fm metadata endpoints."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class LastFMClient:
+    base_url = "https://ws.audioscrobbler.com/2.0/"
+
+    def __init__(self, api_key: str | None, timeout: float = 6.0) -> None:
+        self.api_key = api_key
+        self.timeout = timeout
+
+    async def get_album_info(self, artist: str | None, album: str) -> dict[str, Any] | None:
+        if not self.api_key:
+            logger.debug("lastfm: missing API key, skipping lookup")
+            return None
+        params = {
+            "method": "album.getinfo",
+            "api_key": self.api_key,
+            "format": "json",
+            "album": album,
+        }
+        if artist:
+            params["artist"] = artist
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(self.base_url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("lastfm http error album=%s status=%s", album, exc.response.status_code)
+            return None
+        except httpx.RequestError as exc:
+            logger.warning("lastfm request error album=%s error=%s", album, exc)
+            return None
+
+        album_data = data.get("album") if isinstance(data, dict) else None
+        if not isinstance(album_data, dict):
+            return None
+        tags = album_data.get("tags", {}).get("tag", [])
+        if isinstance(tags, list):
+            tag_list = [t.get("name") for t in tags if isinstance(t, dict) and t.get("name")]
+        else:
+            tag_list = []
+        wiki = album_data.get("wiki") or {}
+        listeners = album_data.get("listeners")
+        playcount = album_data.get("playcount")
+        try:
+            listeners_val = int(listeners) if listeners is not None else None
+        except (TypeError, ValueError):
+            listeners_val = None
+        try:
+            playcount_val = int(playcount) if playcount is not None else None
+        except (TypeError, ValueError):
+            playcount_val = None
+
+        return {
+            "tags": tag_list,
+            "listeners": listeners_val,
+            "playcount": playcount_val,
+            "summary": wiki.get("summary"),
+            "url": album_data.get("url"),
+            "extra": album_data,
+        }
+
+
+__all__ = ["LastFMClient"]
+

--- a/apps/api/app/services/metadata/providers/musicbrainz.py
+++ b/apps/api/app/services/metadata/providers/musicbrainz.py
@@ -1,0 +1,78 @@
+"""MusicBrainz client focusing on release-group discovery."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class MusicBrainzClient:
+    base_url = "https://musicbrainz.org/ws/2"
+
+    def __init__(self, user_agent: str, timeout: float = 8.0) -> None:
+        self.user_agent = user_agent
+        self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {"Accept": "application/json", "User-Agent": self.user_agent}
+
+    async def lookup_release_group(
+        self,
+        artist: str | None,
+        album: str,
+        year: int | None = None,
+    ) -> dict[str, Any] | None:
+        if not album:
+            return None
+        query_parts = [f'release:"{album}"']
+        if artist:
+            query_parts.append(f'artist:"{artist}"')
+        if year:
+            query_parts.append(f'firstreleasedate:{year}')
+        params = {
+            "query": " AND ".join(query_parts),
+            "fmt": "json",
+            "limit": 5,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(f"{self.base_url}/release-group", params=params, headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("mb http error album=%s status=%s", album, exc.response.status_code)
+            return None
+        except httpx.RequestError as exc:
+            logger.warning("mb request error album=%s error=%s", album, exc)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+        groups = data.get("release-groups") or []
+        if not groups:
+            return None
+        best = groups[0]
+        artist_credit = best.get("artist-credit") or []
+        artist_data = artist_credit[0].get("artist") if artist_credit else None
+        return {
+            "artist": {
+                "id": (artist_data or {}).get("id"),
+                "name": (artist_data or {}).get("name"),
+            },
+            "release_group": {
+                "id": best.get("id"),
+                "title": best.get("title"),
+                "first_release_date": best.get("first-release-date"),
+                "primary_type": best.get("primary-type"),
+            },
+            "extra": data,
+        }
+
+
+__all__ = ["MusicBrainzClient"]
+

--- a/apps/api/app/services/metadata/providers/omdb.py
+++ b/apps/api/app/services/metadata/providers/omdb.py
@@ -1,0 +1,44 @@
+"""Thin async wrapper around the OMDb API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class OMDbClient:
+    base_url = "https://www.omdbapi.com/"
+
+    def __init__(self, api_key: str | None, timeout: float = 6.0) -> None:
+        self.api_key = api_key
+        self.timeout = timeout
+
+    async def fetch_by_imdb(self, imdb_id: str) -> dict[str, Any] | None:
+        if not self.api_key:
+            logger.debug("omdb: missing API key, skipping lookup for %s", imdb_id)
+            return None
+        params = {"apikey": self.api_key, "i": imdb_id, "plot": "short"}
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(self.base_url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+                if not isinstance(data, dict):
+                    return None
+                if data.get("Response") == "False":
+                    return None
+                return data
+        except httpx.HTTPStatusError as exc:
+            logger.warning("omdb http error imdb_id=%s status=%s", imdb_id, exc.response.status_code)
+        except httpx.RequestError as exc:
+            logger.warning("omdb request error imdb_id=%s error=%s", imdb_id, exc)
+        return None
+
+
+__all__ = ["OMDbClient"]
+

--- a/apps/api/app/services/metadata/providers/tmdb.py
+++ b/apps/api/app/services/metadata/providers/tmdb.py
@@ -1,0 +1,149 @@
+"""Async client for The Movie Database (TMDb) v3 API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/original"
+
+
+class TMDBClient:
+    """Minimal TMDb wrapper used for movie/TV enrichment."""
+
+    base_url = "https://api.themoviedb.org/3"
+
+    def __init__(self, api_key: str | None, timeout: float = 8.0) -> None:
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {"Accept": "application/json"}
+
+    async def _get(self, path: str, params: dict[str, Any]) -> dict[str, Any] | None:
+        if not self.api_key:
+            logger.debug("tmdb: missing API key, skipping request to %s", path)
+            return None
+        query = {"api_key": self.api_key, **params}
+        url = f"{self.base_url}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(url, params=query, headers=self._headers())
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("tmdb http error path=%s status=%s", path, exc.response.status_code)
+        except httpx.RequestError as exc:
+            logger.warning("tmdb request error path=%s error=%s", path, exc)
+        return None
+
+    async def _search(
+        self,
+        media_type: Literal["movie", "tv"],
+        title: str,
+        year: int | None = None,
+        language: str = "en-US",
+    ) -> dict[str, Any] | None:
+        params: dict[str, Any] = {
+            "query": title,
+            "include_adult": False,
+            "language": language,
+            "page": 1,
+        }
+        if year is not None:
+            params["year" if media_type == "movie" else "first_air_date_year"] = year
+        data = await self._get(f"/search/{media_type}", params)
+        if not data:
+            return None
+        results = data.get("results") or []
+        if not results:
+            return None
+        return results[0]
+
+    async def _details(
+        self,
+        media_type: Literal["movie", "tv"],
+        tmdb_id: int,
+        language: str = "en-US",
+    ) -> dict[str, Any] | None:
+        params = {"language": language, "append_to_response": "external_ids"}
+        return await self._get(f"/{media_type}/{tmdb_id}", params)
+
+    async def movie_lookup(self, title: str, year: int | None = None) -> dict[str, Any] | None:
+        """Return canonical movie details for ``title`` from TMDb."""
+
+        primary = await self._search("movie", title, year=year)
+        if not primary:
+            return None
+        tmdb_id = primary.get("id")
+        if tmdb_id is None:
+            return None
+        details = await self._details("movie", tmdb_id)
+        if not details:
+            return None
+        external = (details.get("external_ids") or {}) if isinstance(details, dict) else {}
+        imdb_id = external.get("imdb_id") if isinstance(external, dict) else None
+        release_date = details.get("release_date") or primary.get("release_date")
+        year_value = None
+        if isinstance(release_date, str) and len(release_date) >= 4:
+            try:
+                year_value = int(release_date[:4])
+            except ValueError:
+                year_value = None
+        poster = details.get("poster_path") or primary.get("poster_path")
+        backdrop = details.get("backdrop_path") or primary.get("backdrop_path")
+        result = {
+            "tmdb_id": tmdb_id,
+            "title": details.get("title") or primary.get("title") or title,
+            "year": year_value,
+            "overview": details.get("overview") or primary.get("overview"),
+            "poster": f"{TMDB_IMAGE_BASE}{poster}" if poster else None,
+            "backdrop": f"{TMDB_IMAGE_BASE}{backdrop}" if backdrop else None,
+            "imdb_id": imdb_id,
+            "extra": {"tmdb": details},
+        }
+        return result
+
+    async def tv_lookup(self, title: str, year: int | None = None) -> dict[str, Any] | None:
+        """Return canonical TV details for ``title`` from TMDb."""
+
+        primary = await self._search("tv", title, year=year)
+        if not primary:
+            return None
+        tmdb_id = primary.get("id")
+        if tmdb_id is None:
+            return None
+        details = await self._details("tv", tmdb_id)
+        if not details:
+            return None
+        external = (details.get("external_ids") or {}) if isinstance(details, dict) else {}
+        imdb_id = external.get("imdb_id") if isinstance(external, dict) else None
+        first_air = details.get("first_air_date") or primary.get("first_air_date")
+        year_value = None
+        if isinstance(first_air, str) and len(first_air) >= 4:
+            try:
+                year_value = int(first_air[:4])
+            except ValueError:
+                year_value = None
+        poster = details.get("poster_path") or primary.get("poster_path")
+        backdrop = details.get("backdrop_path") or primary.get("backdrop_path")
+        result = {
+            "tmdb_id": tmdb_id,
+            "title": details.get("name") or primary.get("name") or title,
+            "year": year_value,
+            "overview": details.get("overview") or primary.get("overview"),
+            "poster": f"{TMDB_IMAGE_BASE}{poster}" if poster else None,
+            "backdrop": f"{TMDB_IMAGE_BASE}{backdrop}" if backdrop else None,
+            "imdb_id": imdb_id,
+            "extra": {"tmdb": details},
+        }
+        return result
+
+
+__all__ = ["TMDBClient"]
+

--- a/apps/api/app/services/metadata/router.py
+++ b/apps/api/app/services/metadata/router.py
@@ -1,0 +1,279 @@
+"""Metadata enrichment router orchestrating provider lookups."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from app.schemas.media import Classification, EnrichedCard, EnrichedProvider
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TTLCache:
+    ttl: float
+    maxsize: int
+    data: Dict[Any, tuple[float, Any]]
+
+    def __init__(self, ttl: float = 900.0, maxsize: int = 256) -> None:
+        self.ttl = ttl
+        self.maxsize = maxsize
+        self.data = {}
+
+    def get(self, key: Any) -> Any | None:
+        entry = self.data.get(key)
+        if not entry:
+            return None
+        ts, value = entry
+        if time.monotonic() - ts > self.ttl:
+            self.data.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: Any, value: Any) -> None:
+        if len(self.data) >= self.maxsize:
+            oldest_key = min(self.data.items(), key=lambda item: item[1][0])[0]
+            self.data.pop(oldest_key, None)
+        self.data[key] = (time.monotonic(), value)
+
+
+class MetadataRouter:
+    """Route classified titles to relevant metadata providers."""
+
+    def __init__(
+        self,
+        *,
+        tmdb_client: Any | None,
+        omdb_client: Any | None,
+        musicbrainz_client: Any | None,
+        discogs_client: Any | None,
+        lastfm_client: Any | None,
+        threshold_low: float = 0.55,
+    ) -> None:
+        self.tmdb = tmdb_client
+        self.omdb = omdb_client
+        self.musicbrainz = musicbrainz_client
+        self.discogs = discogs_client
+        self.lastfm = lastfm_client
+        self.threshold_low = threshold_low
+        self.cache = TTLCache()
+
+    async def enrich(self, classification: Classification, title: str) -> EnrichedCard:
+        """Return an :class:`EnrichedCard` for ``title``."""
+
+        cache_key = (classification.type, title.lower())
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            logger.debug("metadata cache hit for %s", cache_key)
+            return cached.model_copy(deep=True)
+
+        if classification.type == "music":
+            card = await self._enrich_music(classification, title)
+        elif classification.type == "movie":
+            card = await self._enrich_video(classification, title, media_type="movie")
+        elif classification.type == "tv":
+            card = await self._enrich_video(classification, title, media_type="tv")
+        else:
+            card = self._build_base_card(classification, title)
+            card.providers = []
+            card.details["message"] = "No metadata providers available for this type"
+
+        self.cache.set(cache_key, card.model_copy(deep=True))
+        return card
+
+    def _build_base_card(self, classification: Classification, title: str) -> EnrichedCard:
+        return EnrichedCard(
+            media_type=classification.type,
+            confidence=classification.confidence,
+            title=title,
+            ids={},
+            details={},
+            providers=[],
+            reasons=list(classification.reasons),
+            needs_confirmation=classification.confidence < self.threshold_low,
+        )
+
+    async def _enrich_music(self, classification: Classification, title: str) -> EnrichedCard:
+        card = self._build_base_card(classification, title)
+        providers = {
+            "MusicBrainz": EnrichedProvider(name="MusicBrainz", used=False),
+            "Discogs": EnrichedProvider(name="Discogs", used=False),
+            "Last.fm": EnrichedProvider(name="Last.fm", used=False),
+        }
+
+        artist = None
+        album = title
+        year = None
+        match = re.search(r"^(?P<artist>.+?)\s+-\s+(?P<album>.+?)(?:\s*\((?P<year>\d{4})\))?(?:\s|$)", title)
+        if match:
+            artist = match.group("artist").strip()
+            album = match.group("album").strip()
+            if match.group("year"):
+                try:
+                    year = int(match.group("year"))
+                except ValueError:
+                    year = None
+            card.parsed = {"artist": artist, "album": album}
+            if year:
+                card.parsed["year"] = year
+
+        tasks: dict[str, asyncio.Task[Any]] = {}
+        if self.musicbrainz and hasattr(self.musicbrainz, "lookup_release_group"):
+            tasks["MusicBrainz"] = asyncio.create_task(
+                self.musicbrainz.lookup_release_group(artist, album, year)
+            )
+        if self.discogs and getattr(self.discogs, "token", None) and hasattr(self.discogs, "lookup_release"):
+            tasks["Discogs"] = asyncio.create_task(
+                self.discogs.lookup_release(artist, album, year, None)
+            )
+        else:
+            providers["Discogs"].extra = {"error": "not_configured"}
+        if self.lastfm and getattr(self.lastfm, "api_key", None) and hasattr(self.lastfm, "get_album_info"):
+            tasks["Last.fm"] = asyncio.create_task(self.lastfm.get_album_info(artist, album))
+        else:
+            providers["Last.fm"].extra = {"error": "not_configured"}
+
+        results: dict[str, Any] = {}
+        if tasks:
+            gathered = await asyncio.gather(*tasks.values(), return_exceptions=True)
+            for name, result in zip(tasks.keys(), gathered, strict=False):
+                if isinstance(result, Exception):
+                    logger.warning("provider %s failed for title=%s: %s", name, title, result)
+                    providers[name].extra = {"error": str(result)}
+                    continue
+                results[name] = result
+
+        mb_data = results.get("MusicBrainz")
+        if mb_data:
+            providers["MusicBrainz"].used = True
+            providers["MusicBrainz"].extra = {"id": (mb_data.get("release_group") or {}).get("id")}
+            artist_info = mb_data.get("artist") or {}
+            release_group = mb_data.get("release_group") or {}
+            if artist_info.get("id"):
+                card.ids["mb_artist_id"] = artist_info.get("id")
+            if release_group.get("id"):
+                card.ids["mb_release_group_id"] = release_group.get("id")
+            if release_group.get("first_release_date") and "year" not in (card.parsed or {}):
+                try:
+                    card.parsed = card.parsed or {}
+                    card.parsed["year"] = int(release_group["first_release_date"][:4])
+                except Exception:
+                    pass
+            card.details.setdefault("musicbrainz", release_group)
+
+        discogs_data = results.get("Discogs")
+        if discogs_data:
+            providers["Discogs"].used = True
+            providers["Discogs"].extra = {"id": discogs_data.get("id")}
+            card.details.setdefault("discogs", {}).update(discogs_data)
+            if discogs_data.get("cover_image"):
+                card.details.setdefault("images", {})["primary"] = discogs_data["cover_image"]
+
+        lastfm_data = results.get("Last.fm")
+        if lastfm_data:
+            providers["Last.fm"].used = True
+            providers["Last.fm"].extra = {"url": lastfm_data.get("url")}
+            card.details.setdefault("lastfm", {}).update(lastfm_data)
+            tags = lastfm_data.get("tags")
+            if tags:
+                card.details.setdefault("tags", list(tags))
+
+        card.providers = list(providers.values())
+        if card.parsed is None and (artist or album):
+            card.parsed = {"artist": artist, "album": album}
+        return card
+
+    async def _enrich_video(
+        self,
+        classification: Classification,
+        title: str,
+        *,
+        media_type: str,
+    ) -> EnrichedCard:
+        card = self._build_base_card(classification, title)
+        providers = {
+            "TMDb": EnrichedProvider(name="TMDb", used=False),
+            "OMDb": EnrichedProvider(name="OMDb", used=False),
+        }
+
+        year = None
+        match = re.search(r"(19|20)\d{2}", title)
+        if match:
+            try:
+                year = int(match.group())
+            except ValueError:
+                year = None
+        season = None
+        episode = None
+        season_match = re.search(r"S(?P<season>\d{1,2})E(?P<episode>\d{1,2})", title, re.I)
+        if season_match:
+            try:
+                season = int(season_match.group("season"))
+                episode = int(season_match.group("episode"))
+            except ValueError:
+                season = episode = None
+        elif media_type == "tv":
+            season_match = re.search(r"Season\s+(?P<season>\d+)", title, re.I)
+            if season_match:
+                try:
+                    season = int(season_match.group("season"))
+                except ValueError:
+                    season = None
+
+        if season is not None:
+            card.parsed = {"season": season}
+            if episode is not None:
+                card.parsed["episode"] = episode
+        if year is not None:
+            card.parsed = card.parsed or {}
+            card.parsed.setdefault("year", year)
+
+        tmdb_data: Optional[dict[str, Any]] = None
+        if self.tmdb and hasattr(self.tmdb, "movie_lookup") and media_type == "movie":
+            tmdb_data = await self.tmdb.movie_lookup(title, year)
+        elif self.tmdb and hasattr(self.tmdb, "tv_lookup") and media_type == "tv":
+            tmdb_data = await self.tmdb.tv_lookup(title, year)
+        if tmdb_data:
+            providers["TMDb"].used = True
+            card.ids["tmdb_id"] = tmdb_data.get("tmdb_id")
+            if tmdb_data.get("imdb_id"):
+                card.ids["imdb_id"] = tmdb_data["imdb_id"]
+            card.details.setdefault("tmdb", {}).update(tmdb_data)
+            if tmdb_data.get("poster"):
+                card.details.setdefault("images", {})["poster"] = tmdb_data["poster"]
+            if tmdb_data.get("backdrop"):
+                card.details.setdefault("images", {})["backdrop"] = tmdb_data["backdrop"]
+            card.title = tmdb_data.get("title") or card.title
+            card.parsed = card.parsed or {}
+            if tmdb_data.get("year"):
+                card.parsed.setdefault("year", tmdb_data["year"])
+        else:
+            providers["TMDb"].extra = {"error": "no_result"}
+            if classification.type in {"movie", "tv"}:
+                card.reasons.append("tmdb_missing")
+
+        if self.omdb and card.ids.get("imdb_id") and hasattr(self.omdb, "fetch_by_imdb"):
+            omdb_data = await self.omdb.fetch_by_imdb(card.ids["imdb_id"])
+            if omdb_data:
+                providers["OMDb"].used = True
+                card.details.setdefault("omdb", {}).update(omdb_data)
+            else:
+                providers["OMDb"].extra = {"error": "no_result"}
+        else:
+            providers["OMDb"].extra = {"error": "not_configured"}
+
+        card.providers = list(providers.values())
+        if not providers["TMDb"].used:
+            card.needs_confirmation = True
+            card.reasons.append("tmdb_unavailable")
+        return card
+
+
+__all__ = ["MetadataRouter"]
+

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -28,11 +28,45 @@ export async function register(email: string, password: string) {
 }
 
 // ---------- Search & Downloads ----------
-export async function searchApi(q: string, trackers?: string[]) {
-  // Backend accepts GET /search?query=... (optionally with trackers list in body or query — keep it simple GET for now)
-  const url = joinUrl(API_BASE, `/search?query=${encodeURIComponent(q)}`);
+export interface EnrichedProvider {
+  name: string;
+  used: boolean;
+  extra?: Record<string, any> | null;
+}
+
+export interface EnrichedCard {
+  media_type: "music" | "movie" | "tv" | "other";
+  confidence: number;
+  title: string;
+  parsed?: Record<string, any> | null;
+  ids: Record<string, any>;
+  details: Record<string, any>;
+  providers: EnrichedProvider[];
+  reasons: string[];
+  needs_confirmation: boolean;
+}
+
+export interface SearchResponse {
+  items: EnrichedCard[];
+  jackett_ui_url?: string;
+  message?: string;
+  error?: string;
+}
+
+export interface LookupBody {
+  title: string;
+  hint: "music" | "movie" | "tv" | "other" | "auto";
+}
+
+export async function searchMetadata(q: string, limit = 40): Promise<SearchResponse> {
+  const url = joinUrl(API_BASE, `/search?q=${encodeURIComponent(q)}&limit=${limit}`);
   const { data } = await http.get(url);
-  return data;
+  return data as SearchResponse;
+}
+
+export async function lookupMetadata(body: LookupBody): Promise<EnrichedCard> {
+  const { data } = await http.post(joinUrl(API_BASE, "/meta/lookup"), body);
+  return data as EnrichedCard;
 }
 
 export async function listDownloads() {

--- a/apps/web/src/components/OpenJackettCard.tsx
+++ b/apps/web/src/components/OpenJackettCard.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+type Props = {
+  jackettUrl: string;
+  message?: string;
+};
+
+export function OpenJackettCard({ jackettUrl, message }: Props) {
+  const instructions = [
+    "Open Jackett",
+    "Add or configure indexers",
+    "Return to Phelia and run your search again",
+  ];
+
+  return (
+    <div
+      style={{
+        border: "1px solid #d0d7de",
+        borderRadius: 8,
+        padding: 16,
+        background: "#f6f8fa",
+        marginBottom: 16,
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Jackett setup required</h3>
+      {message && <p style={{ marginTop: 0 }}>{message}</p>}
+      <button
+        style={{
+          background: "#0366d6",
+          color: "#fff",
+          border: "none",
+          borderRadius: 4,
+          padding: "8px 14px",
+          cursor: "pointer",
+          marginBottom: 12,
+        }}
+        onClick={() => window.open(jackettUrl, "_blank", "noopener,noreferrer")}
+      >
+        Open Jackett
+      </button>
+      <ol style={{ margin: 0, paddingLeft: 20 }}>
+        {instructions.map((step, index) => (
+          <li key={step} style={{ marginBottom: index === instructions.length - 1 ? 0 : 4 }}>
+            {step}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+export default OpenJackettCard;
+

--- a/apps/web/src/components/ResultCard.tsx
+++ b/apps/web/src/components/ResultCard.tsx
@@ -1,0 +1,216 @@
+import React, { useState } from "react";
+import type { EnrichedCard } from "../api";
+
+type Props = {
+  card: EnrichedCard;
+  onReclassify?: (hint: "music" | "movie" | "tv" | "other") => Promise<void> | void;
+  onUseMagnet?: (magnet?: string) => void;
+  busy?: boolean;
+};
+
+const mediaLabels: Record<EnrichedCard["media_type"], string> = {
+  music: "Music",
+  movie: "Movie",
+  tv: "TV",
+  other: "Other",
+};
+
+export function ResultCard({ card, onReclassify, onUseMagnet, busy }: Props) {
+  const [selectedHint, setSelectedHint] = useState<"music" | "movie" | "tv" | "other">(
+    card.media_type,
+  );
+
+  const imageUrl =
+    card.details?.images?.poster || card.details?.images?.primary || card.details?.discogs?.cover_image;
+
+  const jackettDetails = card.details?.jackett || {};
+
+  async function handleReclassify() {
+    if (!onReclassify) return;
+    await onReclassify(selectedHint);
+  }
+
+  return (
+    <div
+      style={{
+        border: "1px solid #d0d7de",
+        borderRadius: 8,
+        padding: 16,
+        display: "flex",
+        gap: 16,
+        marginBottom: 16,
+      }}
+    >
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={card.title}
+          style={{ width: 120, height: 180, objectFit: "cover", borderRadius: 4 }}
+        />
+      ) : (
+        <div
+          style={{
+            width: 120,
+            height: 180,
+            borderRadius: 4,
+            background: "#f6f8fa",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#57606a",
+            fontSize: 12,
+            textAlign: "center",
+            padding: 8,
+          }}
+        >
+          No artwork
+        </div>
+      )}
+
+      <div style={{ flex: 1 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontWeight: 600,
+            }}
+          >
+            <span
+              style={{
+                padding: "2px 6px",
+                borderRadius: 4,
+                background: "#ddf4ff",
+                color: "#0550ae",
+                fontSize: 12,
+                textTransform: "uppercase",
+              }}
+            >
+              {mediaLabels[card.media_type]}
+            </span>
+            Confidence: {(card.confidence * 100).toFixed(0)}%
+          </span>
+          {jackettDetails?.magnet && (
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                style={{
+                  background: "#1f883d",
+                  color: "white",
+                  border: "none",
+                  borderRadius: 4,
+                  padding: "6px 10px",
+                  cursor: "pointer",
+                }}
+                onClick={() => navigator.clipboard.writeText(String(jackettDetails.magnet))}
+              >
+                Copy magnet
+              </button>
+              {onUseMagnet && (
+                <button
+                  style={{
+                    background: "#0969da",
+                    color: "white",
+                    border: "none",
+                    borderRadius: 4,
+                    padding: "6px 10px",
+                    cursor: "pointer",
+                  }}
+                  onClick={() => onUseMagnet(String(jackettDetails.magnet))}
+                >
+                  Use magnet
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <h3 style={{ marginTop: 8, marginBottom: 8 }}>{card.title}</h3>
+        {card.parsed?.year && (
+          <p style={{ marginTop: 0, marginBottom: 4 }}>Year: {card.parsed.year}</p>
+        )}
+        {card.details?.tmdb?.overview && (
+          <p style={{ marginTop: 0, marginBottom: 8, color: "#57606a" }}>{card.details.tmdb.overview}</p>
+        )}
+        {card.details?.lastfm?.summary && (
+          <p style={{ marginTop: 0, marginBottom: 8, color: "#57606a" }}>{card.details.lastfm.summary}</p>
+        )}
+
+        <div style={{ marginBottom: 8, fontSize: 12, color: "#57606a" }}>
+          Tracker: {jackettDetails?.indexer || jackettDetails?.tracker || "unknown"}
+          {jackettDetails?.seeders != null && (
+            <>
+              {" "}• Seeders: {jackettDetails.seeders}
+            </>
+          )}
+          {jackettDetails?.leechers != null && (
+            <>
+              {" "}• Leechers: {jackettDetails.leechers}
+            </>
+          )}
+        </div>
+
+        {card.reasons.length > 0 && (
+          <div style={{ fontSize: 12, color: "#57606a", marginBottom: 8 }}>
+            Reasons: {card.reasons.join(", ")}
+          </div>
+        )}
+
+        {card.needs_confirmation && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
+            <span style={{ fontSize: 13 }}>Unsure? Choose a type:</span>
+            <select
+              value={selectedHint}
+              onChange={(event) =>
+                setSelectedHint(event.target.value as "music" | "movie" | "tv" | "other")
+              }
+            >
+              <option value="music">Music</option>
+              <option value="movie">Movie</option>
+              <option value="tv">TV</option>
+              <option value="other">Other</option>
+            </select>
+            <button
+              onClick={handleReclassify}
+              disabled={!onReclassify || busy}
+              style={{
+                background: "#8250df",
+                color: "white",
+                border: "none",
+                borderRadius: 4,
+                padding: "6px 10px",
+                cursor: onReclassify && !busy ? "pointer" : "default",
+                opacity: onReclassify && !busy ? 1 : 0.6,
+              }}
+            >
+              Re-run lookup
+            </button>
+          </div>
+        )}
+
+        {card.providers.length > 0 && (
+          <div style={{ marginTop: 12 }}>
+            <strong>Providers</strong>
+            <ul style={{ marginTop: 6, marginBottom: 0, paddingLeft: 18, fontSize: 12 }}>
+              {card.providers.map((provider) => (
+                <li key={provider.name}>
+                  {provider.name} – {provider.used ? "used" : "skipped"}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ResultCard;
+

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,44 @@
+from app.services.metadata.classifier import Classifier
+
+
+def test_movie_inference_from_tokens():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Blade Runner 2049 2160p BluRay x265")
+    assert result.type == "movie"
+    assert result.confidence > classifier.threshold_low
+    assert any(reason.startswith("title:") for reason in result.reasons)
+
+
+def test_tv_detection_from_season_episode_pattern():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Breaking.Bad.S01E02.720p.WEB-DL")
+    assert result.type == "tv"
+    assert result.confidence > classifier.threshold_low
+
+
+def test_music_detection_with_artist_album_pattern():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Radiohead - In Rainbows (2007) [FLAC]")
+    assert result.type == "music"
+    assert result.confidence > classifier.threshold_low
+
+
+def test_category_hint_overrides_title_noise():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Some Random Upload", "Audio/FLAC", None)
+    assert result.type == "music"
+    assert result.confidence > classifier.threshold_low
+
+
+def test_indexer_prior_guides_ambiguous_title():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Live Bootleg", None, "redacted")
+    assert result.type == "music"
+    assert result.confidence > 0.9
+
+
+def test_ambiguous_title_requires_confirmation():
+    classifier = Classifier()
+    result = classifier.classify_torrent("Untitled Release")
+    assert result.type == "other"
+    assert result.confidence == 0.0

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,102 @@
+import asyncio
+
+import pytest
+
+from app.schemas.media import Classification
+from app.services.metadata.router import MetadataRouter
+
+
+class DummyTMDB:
+    async def movie_lookup(self, title: str, year: int | None = None):
+        return {
+            "tmdb_id": 101,
+            "title": "Blade Runner 2049",
+            "year": 2017,
+            "overview": "Replicants and more.",
+            "poster": "http://example/poster.jpg",
+            "backdrop": "http://example/backdrop.jpg",
+            "imdb_id": "tt1856101",
+            "extra": {"source": "tmdb"},
+        }
+
+
+class DummyOMDb:
+    async def fetch_by_imdb(self, imdb_id: str):
+        return {"imdbID": imdb_id, "imdbRating": "8.0"}
+
+
+class DummyMusicBrainz:
+    async def lookup_release_group(self, artist: str | None, album: str, year: int | None = None):
+        return {
+            "artist": {"id": "artist-1", "name": artist},
+            "release_group": {
+                "id": "rg-1",
+                "title": album,
+                "first_release_date": "2007-10-10",
+            },
+        }
+
+
+class DummyDiscogs:
+    token = "token"
+
+    async def lookup_release(self, artist: str | None, album: str, year: int | None, mb_release_group_id: str | None):
+        return {
+            "id": 55,
+            "title": album,
+            "year": year,
+            "label": "XL Recordings",
+            "catalog_number": "XLCD 324",
+            "cover_image": "http://example/discogs.jpg",
+            "formats": ["CD", "FLAC"],
+        }
+
+
+class DummyLastFM:
+    api_key = "key"
+
+    async def get_album_info(self, artist: str | None, album: str):
+        return {
+            "tags": ["alternative", "rock"],
+            "listeners": 1000,
+            "playcount": 5000,
+            "summary": "A seminal record.",
+            "url": "http://last.fm/album",
+        }
+
+
+def test_movie_enrichment_merges_providers():
+    router = MetadataRouter(
+        tmdb_client=DummyTMDB(),
+        omdb_client=DummyOMDb(),
+        musicbrainz_client=None,
+        discogs_client=None,
+        lastfm_client=None,
+    )
+    classification = Classification(type="movie", confidence=0.8, reasons=["category:movies"])
+    card = asyncio.run(router.enrich(classification, "Blade Runner 2049 2160p"))
+
+    assert card.ids["tmdb_id"] == 101
+    assert card.ids["imdb_id"] == "tt1856101"
+    assert card.details["omdb"]["imdbRating"] == "8.0"
+    assert any(p.name == "TMDb" and p.used for p in card.providers)
+
+
+def test_music_pipeline_collects_multiple_sources():
+    router = MetadataRouter(
+        tmdb_client=None,
+        omdb_client=None,
+        musicbrainz_client=DummyMusicBrainz(),
+        discogs_client=DummyDiscogs(),
+        lastfm_client=DummyLastFM(),
+    )
+    classification = Classification(type="music", confidence=0.75, reasons=["title:Artist - Album pattern"])
+    card = asyncio.run(router.enrich(classification, "Radiohead - In Rainbows (2007)"))
+
+    assert card.ids["mb_release_group_id"] == "rg-1"
+    assert card.details["discogs"]["label"] == "XL Recordings"
+    assert "tags" in card.details and "alternative" in card.details["tags"]
+    provider_status = {p.name: p.used for p in card.providers}
+    assert provider_status["MusicBrainz"] is True
+    assert provider_status["Discogs"] is True
+    assert provider_status["Last.fm"] is True


### PR DESCRIPTION
## Summary
- add metadata classification heuristics, enrichment router, and provider clients
- expose metadata-aware search and lookup endpoints and update Jackett adapter
- refresh web UI with enriched result cards, Jackett onboarding card, and API helpers
- add unit tests covering classifier scoring and metadata routing

## Testing
- `pytest` *(fails: docker binary not available for qbittorrent integration tests)*