### PR TITLE
Fix detail dialog data loading

### DIFF
--- a/apps/web/src/app/__tests__/DetailDialog.test.tsx
+++ b/apps/web/src/app/__tests__/DetailDialog.test.tsx
@@ -3,10 +3,12 @@ import DetailDialog from "@/app/components/Detail/DetailDialog";
 import type { DetailResponse } from "@/app/lib/types";
 import { renderWithProviders } from "@/app/test-utils";
 
-const useDetailsMock = vi.fn();
-const detailContentSpy = vi.fn(({ detail }: { detail: DetailResponse }) => (
-  <div data-testid="detail-content">{detail.title}</div>
-));
+const { useDetailsMock, detailContentSpy } = vi.hoisted(() => ({
+  useDetailsMock: vi.fn(),
+  detailContentSpy: vi.fn(({ detail }: { detail: DetailResponse }) => (
+    <div data-testid="detail-content">{detail.title}</div>
+  )),
+}));
 
 vi.mock("@/app/lib/api", () => ({
   useDetails: useDetailsMock,
@@ -50,7 +52,7 @@ describe("DetailDialog", () => {
     useDetailsMock.mockReturnValue({ data: detail, isLoading: false, isError: false });
     renderWithProviders(<DetailDialog kind="movie" id="42" open onOpenChange={() => {}} />);
 
-    expect(detailContentSpy).toHaveBeenCalledWith({ detail });
+    expect(detailContentSpy).toHaveBeenCalledWith({ detail }, expect.anything());
     expect(screen.getByTestId("detail-content")).toHaveTextContent(detail.title);
   });
 });

--- a/apps/web/src/app/components/Detail/DetailDialog.tsx
+++ b/apps/web/src/app/components/Detail/DetailDialog.tsx
@@ -1,97 +1,67 @@
-import * as React from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import type { ReactNode } from "react";
+import { Dialog, DialogContent, DialogFooter } from "@/app/components/ui/dialog";
+import { Button } from "@/app/components/ui/button";
+import { Skeleton } from "@/app/components/ui/skeleton";
+import DetailContent from "@/app/components/Detail/DetailContent";
+import { useDetails } from "@/app/lib/api";
+import type { MediaKind } from "@/app/lib/types";
 
-type MediaItem = {
-  id: string | number;
-  title: string;
-  subtitle?: string;
-  year?: string | number;
-  coverUrl?: string;
-  description?: string;
-};
-
-type DetailDialogProps = {
+interface DetailDialogProps {
+  kind: MediaKind;
+  id: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  item: MediaItem | null;
-  onPrimary?: (item: MediaItem) => void;
-  primaryLabel?: string;
-};
+}
 
-export function DetailDialog({
-  open,
-  onOpenChange,
-  item,
-  onPrimary,
-  primaryLabel = "Add",
-}: DetailDialogProps) {
-  if (!item) {
-    return (
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Nothing selected</DialogTitle>
-            <DialogDescription>Select an item to see details.</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => onOpenChange(false)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
+function LoadingState() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <Skeleton className="h-7 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-[2fr_3fr]">
+        <Skeleton className="aspect-[2/3] w-full rounded-3xl" />
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState() {
+  return (
+    <div className="space-y-2 text-center">
+      <p className="text-lg font-semibold text-foreground">Failed to load details.</p>
+      <p className="text-sm text-muted-foreground">Please try again later.</p>
+    </div>
+  );
+}
+
+function DetailDialog({ kind, id, open, onOpenChange }: DetailDialogProps) {
+  const { data, isLoading, isError } = useDetails(kind, id);
+
+  let content: ReactNode = null;
+
+  if (isLoading) {
+    content = <LoadingState />;
+  } else if (isError) {
+    content = <ErrorState />;
+  } else if (data) {
+    content = <DetailContent detail={data} />;
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="line-clamp-2">{item.title}</DialogTitle>
-          {item.subtitle ? (
-            <DialogDescription className="line-clamp-2">
-              {item.subtitle}
-              {item.year ? ` • ${item.year}` : ""}
-            </DialogDescription>
-          ) : item.year ? (
-            <DialogDescription>{item.year}</DialogDescription>
-          ) : null}
-        </DialogHeader>
-
-        <div className="mt-3 grid grid-cols-3 gap-4">
-          <div className="col-span-1">
-            {item.coverUrl ? (
-              <img
-                src={item.coverUrl}
-                alt={item.title}
-                className="w-full rounded-xl object-cover"
-              />
-            ) : (
-              <div className="aspect-square w-full rounded-xl border" />
-            )}
-          </div>
-          <div className="col-span-2">
-            <p className="text-sm leading-relaxed whitespace-pre-line">
-              {item.description ?? "No description available."}
-            </p>
-          </div>
-        </div>
-
-        <DialogFooter className="mt-4">
+      <DialogContent className="sm:max-w-3xl">
+        {content}
+        <DialogFooter className="mt-6">
           <Button variant="secondary" onClick={() => onOpenChange(false)}>
             Close
           </Button>
-          {onPrimary ? (
-            <Button onClick={() => onPrimary(item)}>{primaryLabel}</Button>
-          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -99,4 +69,3 @@ export function DetailDialog({
 }
 
 export default DetailDialog;
-

--- a/apps/web/src/app/components/ui/tabs.tsx
+++ b/apps/web/src/app/components/ui/tabs.tsx
@@ -10,7 +10,7 @@ interface TabsContextValue {
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 interface TabsProps {
-  defaultValue: string;
+  defaultValue?: string;
   value?: string;
   onValueChange?: (value: string) => void;
   children: ReactNode;
@@ -18,7 +18,7 @@ interface TabsProps {
 }
 
 function Tabs({ defaultValue, value: valueProp, onValueChange, children, className }: TabsProps) {
-  const [valueState, setValueState] = useState(defaultValue);
+  const [valueState, setValueState] = useState(defaultValue ?? valueProp ?? '');
   const value = valueProp ?? valueState;
 
   const context = useMemo<TabsContextValue>(

--- a/apps/web/src/app/routes/details/$kind.$id.tsx
+++ b/apps/web/src/app/routes/details/$kind.$id.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/app/components/ui/button';
 import DetailContent from '@/app/components/Detail/DetailContent';
@@ -7,10 +7,17 @@ import type { MediaKind } from '@/app/lib/types';
 import { Skeleton } from '@/app/components/ui/skeleton';
 
 function DetailPage() {
-  const params = useParams();
+  const { kind = 'movie', id } = useParams();
   const navigate = useNavigate();
-  const mappedKind = useMemo<MediaKind>(() => (params.kind === 'music' ? 'album' : (params.kind as MediaKind)), [params.kind]);
-  const { data, isLoading, isError } = useDetails(mappedKind, params.id);
+  const mappedKind = useMemo<MediaKind>(() => (kind === 'music' ? 'album' : (kind as MediaKind)), [kind]);
+
+  useEffect(() => {
+    if (!id) navigate(-1);
+  }, [id, navigate]);
+
+  if (!id) return null;
+
+  const { data, isLoading, isError } = useDetails(mappedKind, id);
 
   if (isLoading) {
     return (

--- a/apps/web/src/app/routes/details/DetailDialogRoute.tsx
+++ b/apps/web/src/app/routes/details/DetailDialogRoute.tsx
@@ -1,12 +1,19 @@
-import { useNavigate, useParams } from 'react-router-dom';
-import DetailDialog from '@/app/components/Detail/DetailDialog';
-import type { MediaKind } from '@/app/lib/types';
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import DetailDialog from "@/app/components/Detail/DetailDialog";
+import type { MediaKind } from "@/app/lib/types";
 
 function DetailDialogRoute() {
-  const { kind = 'movie', id } = useParams();
+  const { kind = "movie", id } = useParams();
   const navigate = useNavigate();
 
-  const mappedKind: MediaKind = kind === 'music' ? 'album' : (kind as MediaKind);
+  useEffect(() => {
+    if (!id) navigate(-1);
+  }, [id, navigate]);
+
+  if (!id) return null;
+
+  const mappedKind: MediaKind = kind === "music" ? "album" : (kind as MediaKind);
 
   return (
     <DetailDialog

--- a/apps/web/src/app/routes/movies.tsx
+++ b/apps/web/src/app/routes/movies.tsx
@@ -2,14 +2,24 @@ import CatalogGrid from '@/app/components/CatalogGrid';
 import FiltersBar from '@/app/components/FiltersBar';
 import { useQueryParams } from '@/app/hooks/useQueryParams';
 import { useDiscover, useSearch } from '@/app/lib/api';
+import type { DiscoverParams } from '@/app/lib/types';
 
-const defaults = { sort: 'trending', year: '', genre: '', search: '' } as const;
+type FilterState = {
+  sort: NonNullable<DiscoverParams['sort']>;
+  year: string;
+  genre: string;
+  search: string;
+};
 
-type FilterState = typeof defaults;
+const defaults: FilterState = { sort: 'trending', year: '', genre: '', search: '' };
 
 function MoviesPage() {
   const [filters, setFilters] = useQueryParams<FilterState>(defaults);
-  const discoverParams = { sort: filters.sort as FilterState['sort'], year: filters.year || undefined, genre: filters.genre || undefined };
+  const discoverParams = {
+    sort: filters.sort,
+    year: filters.year || undefined,
+    genre: filters.genre || undefined,
+  };
 
   const discoverQuery = useDiscover('movie', discoverParams);
   const searchQuery = useSearch({ q: filters.search ?? '', kind: 'movie' });

--- a/apps/web/src/app/routes/music.tsx
+++ b/apps/web/src/app/routes/music.tsx
@@ -2,18 +2,25 @@ import CatalogGrid from '@/app/components/CatalogGrid';
 import FiltersBar from '@/app/components/FiltersBar';
 import { useQueryParams } from '@/app/hooks/useQueryParams';
 import { useDiscover, useSearch } from '@/app/lib/api';
+import type { DiscoverParams } from '@/app/lib/types';
 
-const defaults = { sort: 'trending', year: '', genre: '', type: '', search: '' } as const;
+type FilterState = {
+  sort: NonNullable<DiscoverParams['sort']>;
+  year: string;
+  genre: string;
+  type: DiscoverParams['type'];
+  search: string;
+};
 
-type FilterState = typeof defaults;
+const defaults: FilterState = { sort: 'trending', year: '', genre: '', type: undefined, search: '' };
 
 function MusicPage() {
   const [filters, setFilters] = useQueryParams<FilterState>(defaults);
   const discoverParams = {
-    sort: filters.sort as FilterState['sort'],
+    sort: filters.sort,
     year: filters.year || undefined,
     genre: filters.genre || undefined,
-    type: (filters.type as 'album' | 'ep' | 'single') || undefined,
+    type: filters.type,
   };
 
   const discoverQuery = useDiscover('album', discoverParams);

--- a/apps/web/src/app/routes/tv.tsx
+++ b/apps/web/src/app/routes/tv.tsx
@@ -2,14 +2,24 @@ import CatalogGrid from '@/app/components/CatalogGrid';
 import FiltersBar from '@/app/components/FiltersBar';
 import { useQueryParams } from '@/app/hooks/useQueryParams';
 import { useDiscover, useSearch } from '@/app/lib/api';
+import type { DiscoverParams } from '@/app/lib/types';
 
-const defaults = { sort: 'trending', year: '', genre: '', search: '' } as const;
+type FilterState = {
+  sort: NonNullable<DiscoverParams['sort']>;
+  year: string;
+  genre: string;
+  search: string;
+};
 
-type FilterState = typeof defaults;
+const defaults: FilterState = { sort: 'trending', year: '', genre: '', search: '' };
 
 function TvPage() {
   const [filters, setFilters] = useQueryParams<FilterState>(defaults);
-  const discoverParams = { sort: filters.sort as FilterState['sort'], year: filters.year || undefined, genre: filters.genre || undefined };
+  const discoverParams = {
+    sort: filters.sort,
+    year: filters.year || undefined,
+    genre: filters.genre || undefined,
+  };
 
   const discoverQuery = useDiscover('tv', discoverParams);
   const searchQuery = useSearch({ q: filters.search ?? '', kind: 'tv' });


### PR DESCRIPTION
## Summary
- restore `DetailDialog` props, hook usage, and loading/error rendering to match the details route
- guard detail routes against missing ids and adjust filter state types used by catalog pages
- update DetailDialog tests to use hoisted mocks and expect the mocked content render call

## Testing
- npm run build
- npm run test -- DetailDialog

------
https://chatgpt.com/codex/tasks/task_e_68d05cb75de883298b194df5ae233feb