### PR TITLE
feat(web): add torrent search dialog

### DIFF
--- a/apps/web/src/app/components/AppShell.tsx
+++ b/apps/web/src/app/components/AppShell.tsx
@@ -4,6 +4,7 @@ import Header from '@/app/components/Header';
 import Sidebar from '@/app/components/Sidebar';
 import CommandPalette from '@/app/components/CommandPalette';
 import DownloadsDrawer from '@/app/components/DownloadsDrawer';
+import TorrentSearchDialog from '@/app/components/TorrentSearchDialog';
 import { useUiState } from '@/app/stores/ui';
 
 function AppShell() {
@@ -27,6 +28,7 @@ function AppShell() {
       </div>
       <CommandPalette />
       <DownloadsDrawer />
+      <TorrentSearchDialog />
     </div>
   );
 }

--- a/apps/web/src/app/components/Detail/DetailHeader.tsx
+++ b/apps/web/src/app/components/Detail/DetailHeader.tsx
@@ -1,13 +1,21 @@
 import { Badge } from '@/app/components/ui/badge';
 import { Button } from '@/app/components/ui/button';
 import type { DetailResponse } from '@/app/lib/types';
-import { Play } from 'lucide-react';
+import { DownloadCloud, Loader2, Play } from 'lucide-react';
+import { useTorrentSearch } from '@/app/stores/torrent-search';
 
 interface DetailHeaderProps {
   detail: DetailResponse;
 }
 
 function DetailHeader({ detail }: DetailHeaderProps) {
+  const fetchTorrents = useTorrentSearch((state) => state.fetchForItem);
+  const { isLoading, activeItem } = useTorrentSearch((state) => ({
+    isLoading: state.isLoading,
+    activeItem: state.activeItem,
+  }));
+  const isCurrentLoading = isLoading && activeItem?.id === detail.id;
+
   return (
     <div className="relative overflow-hidden rounded-3xl border border-border/60 bg-background/80">
       {detail.backdrop ? (
@@ -50,11 +58,32 @@ function DetailHeader({ detail }: DetailHeaderProps) {
           </div>
           <p className="max-w-2xl text-sm leading-relaxed text-white/80">{detail.overview}</p>
           <div className="flex flex-wrap items-center gap-3">
-            <Button size="lg" className="rounded-full bg-[color:var(--accent)] text-black hover:bg-[color:var(--accent)]/90">
-              <Play className="mr-2 h-5 w-5" /> Play
+            <Button
+              size="lg"
+              variant="accent"
+              className="rounded-full"
+              disabled={isCurrentLoading}
+              onClick={() =>
+                void fetchTorrents({
+                  id: detail.id,
+                  title: detail.title,
+                  kind: detail.kind,
+                  year: detail.year,
+                })
+              }
+            >
+              {isCurrentLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Fetching…
+                </>
+              ) : (
+                <>
+                  <DownloadCloud className="mr-2 h-5 w-5" /> Fetch Torrents
+                </>
+              )}
             </Button>
             <Button variant="secondary" size="lg" className="rounded-full bg-white/10 text-white hover:bg-white/20">
-              Add to queue
+              <Play className="mr-2 h-5 w-5" /> Play
             </Button>
           </div>
         </div>

--- a/apps/web/src/app/components/HeroCarousel.tsx
+++ b/apps/web/src/app/components/HeroCarousel.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ChevronLeft, ChevronRight, Play } from 'lucide-react';
+import { ChevronLeft, ChevronRight, DownloadCloud, Loader2 } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import type { DiscoverItem } from '@/app/lib/types';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useTorrentSearch } from '@/app/stores/torrent-search';
 
 interface HeroCarouselProps {
   items: DiscoverItem[];
@@ -27,11 +28,17 @@ function HeroCarousel({ items }: HeroCarouselProps) {
     setIndex(0);
   }, [slides.length]);
 
+  const fetchTorrents = useTorrentSearch((state) => state.fetchForItem);
+  const { isLoading, activeItem } = useTorrentSearch((state) => ({
+    isLoading: state.isLoading,
+    activeItem: state.activeItem,
+  }));
   const current = slides[index];
   if (!current) return null;
 
   const imageSrc = current.backdrop ?? current.poster;
   const hasImage = Boolean(imageSrc);
+  const isCurrentLoading = isLoading && activeItem?.id === current.id;
 
   const goTo = (next: number) => {
     const length = slides.length;
@@ -81,14 +88,27 @@ function HeroCarousel({ items }: HeroCarouselProps) {
             <div className="flex items-center gap-3">
               <Button
                 size="lg"
-                className="rounded-full bg-[color:var(--accent)] text-black shadow-lg hover:bg-[color:var(--accent)]/90"
+                variant="accent"
+                className="rounded-full shadow-lg"
+                disabled={isCurrentLoading}
                 onClick={() =>
-                  navigate(`/details/${current.kind === 'album' ? 'music' : current.kind}/${current.id}`, {
-                    state: { backgroundLocation: location },
+                  void fetchTorrents({
+                    id: current.id,
+                    title: current.title,
+                    kind: current.kind,
+                    year: current.year,
                   })
                 }
               >
-                <Play className="mr-2 h-5 w-5" /> Play Now
+                {isCurrentLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Fetching…
+                  </>
+                ) : (
+                  <>
+                    <DownloadCloud className="mr-2 h-5 w-5" /> Fetch Torrents
+                  </>
+                )}
               </Button>
               <Button
                 variant="ghost"

--- a/apps/web/src/app/components/TorrentSearchDialog.tsx
+++ b/apps/web/src/app/components/TorrentSearchDialog.tsx
@@ -1,0 +1,265 @@
+import { AlertTriangle, DownloadCloud, ExternalLink, Info, Loader2, Magnet } from 'lucide-react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/app/components/ui/dialog';
+import { Badge } from '@/app/components/ui/badge';
+import { Button } from '@/app/components/ui/button';
+import { ScrollArea } from '@/app/components/ui/scroll-area';
+import { useTorrentSearch } from '@/app/stores/torrent-search';
+import type { JackettSearchItem, JackettTorrentDetails } from '@/app/lib/types';
+
+function TorrentSearchDialog() {
+  const {
+    open,
+    setOpen,
+    isLoading,
+    results,
+    message,
+    jackettUiUrl,
+    error,
+    metaError,
+    activeItem,
+    query,
+  } = useTorrentSearch();
+
+  const description = activeItem?.title
+    ? `Aggregated Jackett torrents for "${activeItem.title}"`
+    : 'Aggregated Jackett torrents from configured indexers.';
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-2xl font-semibold">
+            <DownloadCloud className="h-6 w-6 text-[color:var(--accent)]" /> Torrent results
+          </DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 px-8 pb-8">
+          {query ? (
+            <p className="text-xs text-muted-foreground">Search query: <span className="font-mono text-foreground/80">{query}</span></p>
+          ) : null}
+          {message ? <MessageBanner message={message} jackettUiUrl={jackettUiUrl} /> : null}
+          {metaError ? <WarningBanner message={metaError} jackettUiUrl={jackettUiUrl} /> : null}
+          {isLoading ? (
+            <LoadingState />
+          ) : error ? (
+            <ErrorState message={error} jackettUiUrl={jackettUiUrl} />
+          ) : results.length ? (
+            <ResultsList items={results} />
+          ) : (
+            <EmptyState jackettUiUrl={jackettUiUrl} />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-border/60 bg-background/60 p-8 text-sm text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin text-[color:var(--accent)]" />
+        <p>Fetching torrents…</p>
+      </div>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="animate-pulse space-y-3 rounded-2xl border border-border/60 bg-background/60 p-4 shadow-sm"
+        >
+          <div className="h-5 w-2/3 rounded bg-foreground/10" />
+          <div className="h-3 w-full rounded bg-foreground/5" />
+          <div className="h-3 w-3/4 rounded bg-foreground/5" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MessageBanner({ message, jackettUiUrl }: { message: string; jackettUiUrl?: string }) {
+  return (
+    <div className="flex flex-wrap items-start gap-3 rounded-2xl border border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+      <Info className="mt-0.5 h-5 w-5 text-[color:var(--accent)]" />
+      <div className="space-y-2">
+        <p>{message}</p>
+        <JackettLink jackettUiUrl={jackettUiUrl} />
+      </div>
+    </div>
+  );
+}
+
+function WarningBanner({ message, jackettUiUrl }: { message: string; jackettUiUrl?: string }) {
+  return (
+    <div className="flex flex-wrap items-start gap-3 rounded-2xl border border-orange-300/40 bg-orange-400/10 p-4 text-sm text-orange-200">
+      <AlertTriangle className="mt-0.5 h-5 w-5" />
+      <div className="space-y-2">
+        <p>{message}</p>
+        <JackettLink jackettUiUrl={jackettUiUrl} />
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message, jackettUiUrl }: { message: string; jackettUiUrl?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-destructive/40 bg-destructive/10 p-8 text-center text-sm text-destructive">
+      <AlertTriangle className="h-8 w-8" />
+      <p>{message}</p>
+      <JackettLink jackettUiUrl={jackettUiUrl} />
+    </div>
+  );
+}
+
+function EmptyState({ jackettUiUrl }: { jackettUiUrl?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/60 bg-background/60 p-8 text-center text-sm text-muted-foreground">
+      <DownloadCloud className="h-8 w-8 text-muted-foreground" />
+      <p>No torrents were returned for this query.</p>
+      <JackettLink jackettUiUrl={jackettUiUrl} />
+    </div>
+  );
+}
+
+function JackettLink({ jackettUiUrl }: { jackettUiUrl?: string }) {
+  if (!jackettUiUrl) return null;
+  return (
+    <Button asChild variant="outline" size="sm" className="w-fit">
+      <a href={jackettUiUrl} target="_blank" rel="noreferrer">
+        <ExternalLink className="mr-2 h-4 w-4" /> Open Jackett
+      </a>
+    </Button>
+  );
+}
+
+function ResultsList({ items }: { items: JackettSearchItem[] }) {
+  return (
+    <ScrollArea className="max-h-[60vh] pr-2">
+      <div className="space-y-4">
+        {items.map((item, index) => (
+          <TorrentResultCard key={`${item.title}-${index}`} item={item} />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function TorrentResultCard({ item }: { item: JackettSearchItem }) {
+  const details = (item.details?.jackett ?? {}) as JackettTorrentDetails;
+  const magnetLink = typeof details.magnet === 'string' && details.magnet.length > 0 ? details.magnet : undefined;
+  const downloadUrl = typeof details.url === 'string' && details.url.length > 0 ? details.url : undefined;
+  const indexerName = getIndexerName(details.indexer);
+  const category = formatCategory(details.category);
+  const confidence = Math.round(item.confidence * 100);
+  const sizeLabel = formatSize(details.size);
+  const reasons = item.reasons?.length ? item.reasons : [];
+  const seeders = isNumber(details.seeders) ? details.seeders : undefined;
+  const leechers = isNumber(details.leechers) ? details.leechers : undefined;
+  const tracker = typeof details.tracker === 'string' ? details.tracker : undefined;
+  const providers = Array.isArray(item.providers) ? item.providers.filter((provider) => provider.used) : [];
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-border/60 bg-background/60 p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">{item.title}</h3>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="outline" className="uppercase tracking-wide text-foreground/80">
+              {item.media_type}
+            </Badge>
+            <Badge variant="accent">{confidence}% match</Badge>
+            {item.needs_confirmation ? (
+              <Badge variant="outline" className="border-orange-400 text-orange-300">
+                Needs confirmation
+              </Badge>
+            ) : null}
+            {indexerName ? (
+              <Badge variant="outline" className="text-foreground/70">
+                {indexerName}
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+        {sizeLabel ? <p className="text-sm text-muted-foreground">{sizeLabel}</p> : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+        {seeders !== undefined ? <span>Seeders: {seeders}</span> : null}
+        {leechers !== undefined ? <span>Leechers: {leechers}</span> : null}
+        {tracker ? <span>Tracker: {tracker}</span> : null}
+        {category ? <span>Category: {category}</span> : null}
+      </div>
+      {providers.length ? (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span className="font-semibold text-foreground/80">Providers:</span>
+          {providers.map((provider) => (
+            <Badge key={provider.name} variant="default" className="bg-foreground/10 text-foreground/80">
+              {provider.name}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        {magnetLink ? (
+          <Button asChild size="sm" variant="ghost">
+            <a href={magnetLink} target="_blank" rel="noreferrer">
+              <Magnet className="mr-2 h-4 w-4" /> Magnet link
+            </a>
+          </Button>
+        ) : null}
+        {downloadUrl ? (
+          <Button asChild size="sm" variant="ghost">
+            <a href={downloadUrl} target="_blank" rel="noreferrer">
+              <ExternalLink className="mr-2 h-4 w-4" /> Open source
+            </a>
+          </Button>
+        ) : null}
+      </div>
+      {reasons.length ? (
+        <div className="text-xs text-muted-foreground">
+          <span className="font-semibold text-foreground/80">Notes:</span> {reasons.join(', ')}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function getIndexerName(indexer: JackettTorrentDetails['indexer']): string | undefined {
+  if (!indexer) return undefined;
+  if (typeof indexer === 'string') return indexer;
+  if (typeof indexer === 'object' && indexer !== null) {
+    const maybeName =
+      typeof indexer.name === 'string'
+        ? indexer.name
+        : typeof indexer.id === 'string'
+          ? indexer.id
+          : undefined;
+    if (maybeName) return maybeName;
+  }
+  return undefined;
+}
+
+function formatCategory(category: JackettTorrentDetails['category']): string | undefined {
+  if (!category) return undefined;
+  if (Array.isArray(category)) {
+    return category.filter((value) => typeof value === 'string').join(', ');
+  }
+  return typeof category === 'string' ? category : undefined;
+}
+
+function formatSize(size: JackettTorrentDetails['size']): string | undefined {
+  if (size === null || size === undefined) return undefined;
+  if (typeof size === 'string') return size;
+  if (!Number.isFinite(size)) return undefined;
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = size;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || value % 1 === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export default TorrentSearchDialog;

--- a/apps/web/src/app/lib/api.ts
+++ b/apps/web/src/app/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   DiscoverItem,
   DiscoverParams,
   DownloadItem,
+  JackettSearchResponse,
   LibraryItemSummary,
   ListMutationInput,
   PaginatedResponse,
@@ -187,6 +188,16 @@ export function useCapabilities() {
       }
 
       return capabilities;
+    },
+  });
+}
+
+export function fetchJackettSearch(query: string, options?: { limit?: number }) {
+  const limit = options?.limit;
+  return http<JackettSearchResponse>('search', {
+    query: {
+      q: query,
+      ...(typeof limit === 'number' ? { limit } : {}),
     },
   });
 }

--- a/apps/web/src/app/lib/types.ts
+++ b/apps/web/src/app/lib/types.ts
@@ -56,6 +56,47 @@ export interface AvailabilityInfo {
   torrents?: Array<{ provider: string; seeders?: number; size?: string }>;
 }
 
+export interface EnrichedProvider {
+  name: string;
+  used: boolean;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface JackettTorrentDetails {
+  magnet?: string | null;
+  url?: string | null;
+  size?: string | number | null;
+  seeders?: number | null;
+  leechers?: number | null;
+  tracker?: string | null;
+  indexer?: string | Record<string, unknown> | null;
+  category?: string | string[] | null;
+  title?: string | null;
+}
+
+export interface JackettSearchItem {
+  media_type: 'music' | 'movie' | 'tv' | 'other';
+  confidence: number;
+  title: string;
+  parsed?: Record<string, unknown> | null;
+  ids: Record<string, unknown>;
+  details: Record<string, unknown> & { jackett?: JackettTorrentDetails };
+  providers: EnrichedProvider[];
+  reasons: string[];
+  needs_confirmation: boolean;
+}
+
+export interface JackettSearchResponseMeta {
+  message?: string;
+  jackett_ui_url?: string;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export interface JackettSearchResponse extends JackettSearchResponseMeta {
+  items: JackettSearchItem[];
+}
+
 export interface ExternalLink {
   label: string;
   url: string;

--- a/apps/web/src/app/stores/torrent-search.ts
+++ b/apps/web/src/app/stores/torrent-search.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand';
+import { fetchJackettSearch } from '@/app/lib/api';
+import type { JackettSearchItem, MediaKind } from '@/app/lib/types';
+
+interface TorrentSearchItemContext {
+  id?: string;
+  title: string;
+  kind?: MediaKind;
+  year?: number;
+}
+
+interface TorrentSearchState {
+  open: boolean;
+  isLoading: boolean;
+  results: JackettSearchItem[];
+  message?: string;
+  jackettUiUrl?: string;
+  error?: string;
+  metaError?: string;
+  activeItem?: TorrentSearchItemContext;
+  query?: string;
+  fetchForItem: (item: TorrentSearchItemContext) => Promise<void>;
+  setOpen: (open: boolean) => void;
+}
+
+function buildQuery(item: TorrentSearchItemContext): string {
+  const parts = [item.title?.trim() ?? ''];
+  if (item.year) {
+    parts.push(String(item.year));
+  }
+  return parts
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(' ');
+}
+
+export const useTorrentSearch = create<TorrentSearchState>((set) => ({
+  open: false,
+  isLoading: false,
+  results: [],
+  message: undefined,
+  jackettUiUrl: undefined,
+  error: undefined,
+  metaError: undefined,
+  activeItem: undefined,
+  query: undefined,
+  async fetchForItem(item) {
+    const query = buildQuery(item);
+    if (!query) {
+      set({
+        open: true,
+        isLoading: false,
+        results: [],
+        error: 'Unable to fetch torrents without a title.',
+        metaError: undefined,
+        message: undefined,
+        jackettUiUrl: undefined,
+        activeItem: item,
+        query: undefined,
+      });
+      return;
+    }
+
+    set({
+      open: true,
+      isLoading: true,
+      results: [],
+      error: undefined,
+      metaError: undefined,
+      message: undefined,
+      jackettUiUrl: undefined,
+      activeItem: item,
+      query,
+    });
+
+    try {
+      const response = await fetchJackettSearch(query);
+      set({
+        isLoading: false,
+        results: response.items ?? [],
+        message: typeof response.message === 'string' ? response.message : undefined,
+        jackettUiUrl:
+          typeof response.jackett_ui_url === 'string' ? response.jackett_ui_url : undefined,
+        metaError: typeof response.error === 'string' ? response.error : undefined,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to fetch torrent results.';
+      set({
+        isLoading: false,
+        results: [],
+        error: message,
+      });
+    }
+  },
+  setOpen(open) {
+    set((state) => ({
+      open,
+      isLoading: open ? state.isLoading : false,
+    }));
+  },
+}));


### PR DESCRIPTION
## Summary
- add Jackett search response types and client helper for invoking the `/search` endpoint
- introduce a Zustand-powered torrent search store and dialog UI to display Jackett results with status messaging
- update hero and detail CTAs to trigger torrent fetching and open the new dialog for consistent workflows

## Testing
- npm --prefix apps/web run lint *(fails: import resolver errors due to unsupported TypeScript version in eslint tooling)*
- npm --prefix apps/web run test *(fails: existing unit tests timing out and expectations unrelated to new changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d07714b97c8329b5b12869f156fe81