### PR TITLE
Add download mutation integration and adjust tests

### DIFF
--- a/apps/web/src/app/__tests__/FiltersBar.test.tsx
+++ b/apps/web/src/app/__tests__/FiltersBar.test.tsx
@@ -11,10 +11,18 @@ describe("FiltersBar", () => {
   };
 
   it("updates search and sort filters", async () => {
+    let currentFilters = { ...baseFilters };
     const onChange = vi.fn();
     const user = userEvent.setup();
 
-    renderWithProviders(<FiltersBar kind="movie" filters={baseFilters} onChange={onChange} />);
+    const { rerender } = renderWithProviders(
+      <FiltersBar kind="movie" filters={currentFilters} onChange={onChange} />,
+    );
+
+    onChange.mockImplementation((next) => {
+      currentFilters = { ...currentFilters, ...next };
+      rerender(<FiltersBar kind="movie" filters={currentFilters} onChange={onChange} />);
+    });
 
     const searchInput = screen.getByPlaceholderText(/search movies/i);
     await user.type(searchInput, "Matrix");

--- a/apps/web/src/app/__tests__/GlobalSearch.test.tsx
+++ b/apps/web/src/app/__tests__/GlobalSearch.test.tsx
@@ -76,7 +76,7 @@ describe("GlobalSearch", () => {
       vi.advanceTimersByTime(400);
     });
 
-    await screen.findByText("The Matrix");
+    expect(screen.getByText("The Matrix")).toBeInTheDocument();
 
     await user.keyboard("{ArrowDown}{Enter}");
 

--- a/apps/web/src/app/__tests__/TorrentSearchDialog.test.tsx
+++ b/apps/web/src/app/__tests__/TorrentSearchDialog.test.tsx
@@ -1,0 +1,89 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TorrentSearchDialog from "@/app/components/TorrentSearchDialog";
+import type { JackettSearchItem } from "@/app/lib/types";
+import { renderWithProviders } from "@/app/test-utils";
+
+const { mutateAsync, resetMock, setOpenMock } = vi.hoisted(() => ({
+  mutateAsync: vi.fn(),
+  resetMock: vi.fn(),
+  setOpenMock: vi.fn(),
+}));
+
+const mockResult: JackettSearchItem = {
+  media_type: "movie",
+  confidence: 0.87,
+  title: "Example Torrent",
+  ids: {},
+  details: {
+    jackett: {
+      magnet: "magnet:?xt=urn:btih:example",
+      url: "https://example.com/torrent",
+      size: "1 GB",
+      indexer: "Indexer",
+      category: "Movies",
+      seeders: 12,
+      leechers: 3,
+      tracker: "ExampleTracker",
+    },
+  },
+  providers: [],
+  reasons: [],
+  needs_confirmation: false,
+};
+
+const mockTorrentState = {
+  open: true,
+  setOpen: setOpenMock,
+  isLoading: false,
+  results: [mockResult],
+  message: undefined as string | undefined,
+  jackettUiUrl: undefined as string | undefined,
+  error: undefined as string | undefined,
+  metaError: undefined as string | undefined,
+  activeItem: { title: "Example Torrent" },
+  query: "Example Torrent",
+};
+
+vi.mock("@/app/stores/torrent-search", () => ({
+  useTorrentSearch: (selector?: (state: typeof mockTorrentState) => unknown) =>
+    selector ? selector(mockTorrentState) : mockTorrentState,
+}));
+
+vi.mock("@/app/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/app/lib/api")>("@/app/lib/api");
+  return {
+    ...actual,
+    useCreateDownload: () => ({
+      mutateAsync,
+      isPending: false,
+      error: null,
+      reset: resetMock,
+    }),
+  };
+});
+
+describe("TorrentSearchDialog", () => {
+  beforeEach(() => {
+    mutateAsync.mockReset().mockResolvedValue({ success: true });
+    resetMock.mockReset();
+    setOpenMock.mockReset();
+    mockTorrentState.results = [mockResult];
+    mockTorrentState.error = undefined;
+    mockTorrentState.metaError = undefined;
+    mockTorrentState.message = undefined;
+    mockTorrentState.open = true;
+  });
+
+  it("invokes the create download mutation when add download clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TorrentSearchDialog />);
+
+    await user.click(screen.getByRole("button", { name: /add download/i }));
+
+    await waitFor(() => {
+      expect(resetMock).toHaveBeenCalled();
+      expect(mutateAsync).toHaveBeenCalledWith({ magnet: "magnet:?xt=urn:btih:example" });
+    });
+  });
+});

--- a/apps/web/src/app/components/MediaCard/MediaCardBase.tsx
+++ b/apps/web/src/app/components/MediaCard/MediaCardBase.tsx
@@ -8,6 +8,7 @@ import { useMutateList } from '@/app/lib/api';
 import { toast } from 'sonner';
 import { Badge } from '@/app/components/ui/badge';
 import { cn } from '@/app/utils/cn';
+import { useTorrentSearch } from '@/app/stores/torrent-search';
 
 interface MediaCardBaseProps {
   item: DiscoverItem;
@@ -21,6 +22,7 @@ const MediaCardBase = forwardRef<HTMLDivElement, MediaCardBaseProps>(({ item, ta
   const location = useLocation();
   const [hovered, setHovered] = useState(false);
   const mutation = useMutateList();
+  const fetchTorrentSearch = useTorrentSearch((state) => state.fetchForItem);
 
   const openDetails = () => {
     navigate(`/details/${item.kind === 'album' ? 'music' : item.kind}/${item.id}`, {
@@ -135,9 +137,15 @@ const MediaCardBase = forwardRef<HTMLDivElement, MediaCardBaseProps>(({ item, ta
               variant="ghost"
               size="sm"
               className="h-8 rounded-full px-3"
+              aria-label="Open torrent search"
               onClick={(event) => {
                 event.stopPropagation();
-                toast('Download queued', { description: `${item.title} will download shortly.` });
+                void fetchTorrentSearch({
+                  id: item.id,
+                  title: item.title,
+                  kind: item.kind,
+                  year: item.year,
+                });
               }}
             >
               <Download className="mr-2 h-4 w-4" />

--- a/apps/web/src/app/lib/api.ts
+++ b/apps/web/src/app/lib/api.ts
@@ -154,6 +154,26 @@ export function useDownloads(enabled = true) {
   });
 }
 
+export interface CreateDownloadInput {
+  magnet?: string;
+  url?: string;
+}
+
+export function useCreateDownload() {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: boolean }, Error, CreateDownloadInput>({
+    mutationFn: (input) =>
+      http<{ success: boolean }>('downloads', {
+        method: 'POST',
+        json: input,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['downloads'] });
+    },
+  });
+}
+
 export function useLibrary() {
   return useQuery<LibraryItemSummary, Error>({
     queryKey: ['library'],


### PR DESCRIPTION
## Summary
- add a `useCreateDownload` helper that posts downloads and invalidates the downloads query on success
- update torrent search results to offer an "Add download" action that uses the mutation, includes feedback, and keeps advanced links
- trigger torrent search from media cards and expand related tests to cover the new mutation flow

## Testing
- pnpm test