### PR TITLE
Add provider credential persistence settings API

### DIFF
--- a/apps/api/alembic/versions/f35b2f12e9dc_create_provider_credentials_table.py
+++ b/apps/api/alembic/versions/f35b2f12e9dc_create_provider_credentials_table.py
@@ -1,0 +1,37 @@
+"""create provider credentials table
+
+Revision ID: f35b2f12e9dc
+Revises: 53c5c7dc5baf
+Create Date: 2024-11-01
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "f35b2f12e9dc"
+down_revision = "53c5c7dc5baf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_credentials",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("api_key", sa.String(length=512), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("provider", name="uq_provider_credentials_provider"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("provider_credentials")

--- a/apps/api/app/api/v1/endpoints/settings.py
+++ b/apps/api/app/api/v1/endpoints/settings.py
@@ -1,0 +1,55 @@
+"""Settings management endpoints for provider credentials."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.schemas.settings import (
+    ProviderCredentialPayload,
+    ProviderCredentialStatus,
+    ProviderCredentialsResponse,
+)
+from app.services import settings as settings_service
+from app.services.settings import UnsupportedProviderError
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("/providers", response_model=ProviderCredentialsResponse)
+def list_providers(db: Session = Depends(get_db)) -> ProviderCredentialsResponse:
+    stored = settings_service.list_provider_credentials(db)
+    statuses: list[ProviderCredentialStatus] = []
+    for provider in settings_service.supported_providers():
+        record = stored.get(provider)
+        api_key = record.api_key if record else None
+        statuses.append(
+            ProviderCredentialStatus(
+                provider=provider,
+                configured=bool(api_key),
+                masked_api_key=settings_service.mask_api_key(api_key),
+            )
+        )
+    return ProviderCredentialsResponse(providers=statuses)
+
+
+@router.put("/providers/{provider}", response_model=ProviderCredentialStatus)
+def upsert_provider(
+    provider: str,
+    payload: ProviderCredentialPayload,
+    db: Session = Depends(get_db),
+) -> ProviderCredentialStatus:
+    raw_key = payload.api_key
+    normalized_key = raw_key.strip() if isinstance(raw_key, str) else None
+    api_key = normalized_key or None
+    try:
+        record = settings_service.upsert_provider_credential(db, provider, api_key)
+    except UnsupportedProviderError:
+        raise HTTPException(status_code=404, detail={"error": "unknown_provider"})
+
+    return ProviderCredentialStatus(
+        provider=record.provider,
+        configured=bool(record.api_key),
+        masked_api_key=settings_service.mask_api_key(record.api_key),
+    )

--- a/apps/api/app/db/models.py
+++ b/apps/api/app/db/models.py
@@ -113,3 +113,25 @@ class LibraryPlaylist(Base):
         onupdate=datetime.utcnow,
         server_default=func.now(),
     )
+
+
+class ProviderCredential(Base):
+    __tablename__ = "provider_credentials"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    provider: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    api_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("provider", name="uq_provider_credentials_provider"),
+    )

--- a/apps/api/app/schemas/settings.py
+++ b/apps/api/app/schemas/settings.py
@@ -1,0 +1,33 @@
+"""Schemas for provider settings management endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProviderCredentialPayload(BaseModel):
+    """Input payload when updating a provider API key."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_key: str | None = Field(
+        default=None,
+        description="API key/token to store for the provider.",
+    )
+
+
+class ProviderCredentialStatus(BaseModel):
+    """Status information returned for configured providers."""
+
+    provider: str
+    configured: bool
+    masked_api_key: str | None = Field(
+        default=None,
+        description="Masked representation of the stored key.",
+    )
+
+
+class ProviderCredentialsResponse(BaseModel):
+    """Envelope listing provider credential configuration."""
+
+    providers: list[ProviderCredentialStatus] = Field(default_factory=list)

--- a/apps/api/app/services/settings.py
+++ b/apps/api/app/services/settings.py
@@ -1,0 +1,120 @@
+"""Persistence helpers for provider credential configuration."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.models import ProviderCredential
+from app.services.metadata import get_metadata_router
+
+SUPPORTED_PROVIDER_SETTINGS: dict[str, str] = {
+    "tmdb": "TMDB_API_KEY",
+    "omdb": "OMDB_API_KEY",
+    "discogs": "DISCOGS_TOKEN",
+    "lastfm": "LASTFM_API_KEY",
+}
+
+
+class UnsupportedProviderError(ValueError):
+    """Raised when attempting to use a provider that isn't supported."""
+
+
+def supported_providers() -> list[str]:
+    """Return the list of providers supported by the persistence layer."""
+
+    return list(SUPPORTED_PROVIDER_SETTINGS.keys())
+
+
+def _normalize_provider(provider: str) -> str:
+    return provider.strip().lower()
+
+
+def _apply_to_settings(provider: str, api_key: str | None) -> bool:
+    attr = SUPPORTED_PROVIDER_SETTINGS.get(provider)
+    if not attr:
+        return False
+    current = getattr(settings, attr, None)
+    if current == api_key:
+        return False
+    setattr(settings, attr, api_key)
+    return True
+
+
+def _clear_metadata_cache() -> None:
+    cache_clear = getattr(get_metadata_router, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+
+
+def load_provider_credentials(db: Session) -> dict[str, str | None]:
+    """Load persisted credentials into the running settings instance."""
+
+    try:
+        rows = db.execute(select(ProviderCredential)).scalars().all()
+    except (OperationalError, ProgrammingError):
+        db.rollback()
+        return {}
+
+    applied: dict[str, str | None] = {}
+    mutated = False
+    for row in rows:
+        provider = _normalize_provider(row.provider)
+        if provider not in SUPPORTED_PROVIDER_SETTINGS:
+            continue
+        applied[provider] = row.api_key
+        mutated |= _apply_to_settings(provider, row.api_key)
+
+    if mutated:
+        _clear_metadata_cache()
+
+    return applied
+
+
+def list_provider_credentials(db: Session) -> dict[str, ProviderCredential]:
+    """Return provider credential rows keyed by provider name."""
+
+    try:
+        rows = db.execute(select(ProviderCredential)).scalars().all()
+    except (OperationalError, ProgrammingError):
+        db.rollback()
+        return {}
+    return {_normalize_provider(row.provider): row for row in rows}
+
+
+def upsert_provider_credential(
+    db: Session, provider: str, api_key: str | None
+) -> ProviderCredential:
+    """Insert or update the credential for ``provider`` and sync settings."""
+
+    normalized = _normalize_provider(provider)
+    if normalized not in SUPPORTED_PROVIDER_SETTINGS:
+        raise UnsupportedProviderError(provider)
+
+    stmt = select(ProviderCredential).where(ProviderCredential.provider == normalized)
+    existing = db.execute(stmt).scalar_one_or_none()
+
+    if existing is None:
+        existing = ProviderCredential(provider=normalized, api_key=api_key)
+        db.add(existing)
+    else:
+        existing.api_key = api_key
+
+    db.flush()
+
+    _apply_to_settings(normalized, api_key)
+    _clear_metadata_cache()
+
+    return existing
+
+
+def mask_api_key(api_key: str | None) -> str | None:
+    """Return a masked representation suitable for API responses."""
+
+    if not api_key:
+        return None
+    if len(api_key) <= 4:
+        return "*" * len(api_key)
+    return f"{'*' * (len(api_key) - 4)}{api_key[-4:]}"

--- a/apps/api/tests/test_settings_endpoints.py
+++ b/apps/api/tests/test_settings_endpoints.py
@@ -1,0 +1,102 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api.v1.endpoints import capabilities as capabilities_router
+from app.api.v1.endpoints import settings as settings_router
+from app.core.config import settings
+from app.db.models import ProviderCredential
+from app.db.session import get_db
+from app.services import settings as settings_service
+
+
+class DummyQbClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):  # pragma: no cover - nothing to clean up
+        return None
+
+    async def login(self):  # pragma: no cover - exercised via test
+        return None
+
+    async def list_torrents(self):  # pragma: no cover - exercised via test
+        return []
+
+
+def test_load_provider_credentials_populates_settings(db_session, monkeypatch):
+    db_session.add(ProviderCredential(provider="tmdb", api_key="tmdb-key"))
+    db_session.add(ProviderCredential(provider="omdb", api_key="omdb-key"))
+    db_session.commit()
+
+    monkeypatch.setattr(settings, "TMDB_API_KEY", None)
+    monkeypatch.setattr(settings, "OMDB_API_KEY", None)
+
+    cleared: list[bool] = []
+
+    def fake_clear():
+        cleared.append(True)
+
+    monkeypatch.setattr(settings_service.get_metadata_router, "cache_clear", fake_clear)
+
+    applied = settings_service.load_provider_credentials(db_session)
+
+    assert settings.TMDB_API_KEY == "tmdb-key"
+    assert settings.OMDB_API_KEY == "omdb-key"
+    assert applied == {"tmdb": "tmdb-key", "omdb": "omdb-key"}
+    assert cleared  # cache clear triggered
+
+
+@pytest.mark.anyio
+async def test_settings_router_updates_credentials(db_session, monkeypatch):
+    monkeypatch.setattr(settings_service.get_metadata_router, "cache_clear", lambda: None)
+    monkeypatch.setattr(capabilities_router, "QbClient", lambda *args, **kwargs: DummyQbClient())
+    monkeypatch.setattr(settings, "TMDB_API_KEY", None)
+
+    app = FastAPI()
+    app.include_router(settings_router.router, prefix="/api/v1")
+    app.include_router(capabilities_router.router, prefix="/api/v1")
+    app.dependency_overrides[get_db] = lambda: db_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/settings/providers")
+        assert resp.status_code == 200
+        providers = {row["provider"]: row for row in resp.json()["providers"]}
+        assert providers["tmdb"]["configured"] is False
+
+        resp = await client.put(
+            "/api/v1/settings/providers/tmdb",
+            json={"api_key": "tmdb-secret"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "tmdb"
+        assert body["configured"] is True
+        assert body["masked_api_key"].endswith("cret")
+
+        resp = await client.get("/api/v1/capabilities")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["services"]["tmdb"] is True
+
+        resp = await client.get("/api/v1/settings/providers")
+        providers = {row["provider"]: row for row in resp.json()["providers"]}
+        assert providers["tmdb"]["configured"] is True
+        assert providers["tmdb"]["masked_api_key"].endswith("cret")
+
+
+@pytest.mark.anyio
+async def test_settings_router_rejects_unknown_provider(db_session):
+    app = FastAPI()
+    app.include_router(settings_router.router, prefix="/api/v1")
+    app.dependency_overrides[get_db] = lambda: db_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            "/api/v1/settings/providers/unknown",
+            json={"api_key": "value"},
+        )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error"] == "unknown_provider"


### PR DESCRIPTION
## Summary
- add an Alembic migration and ORM model for storing provider API credentials with a unique provider constraint
- implement persistence helpers, schemas, and FastAPI routes to list and upsert provider keys while refreshing cached metadata clients
- load saved credentials during startup, register the new router, and extend the test suite for credential loading and capability updates

## Testing
- `pytest apps/api/tests/test_settings_endpoints.py`
- `pytest apps/api/tests` *(fails: docker executable not available in environment)*