### PR TITLE
Fix provider credentials migration parent revision

### DIFF
--- a/apps/api/alembic/versions/f35b2f12e9dc_create_provider_credentials_table.py
+++ b/apps/api/alembic/versions/f35b2f12e9dc_create_provider_credentials_table.py
@@ -1,7 +1,7 @@
 """create provider credentials table
 
 Revision ID: f35b2f12e9dc
-Revises: 53c5c7dc5baf
+Revises: e6f4f3021f2b
 Create Date: 2024-11-01
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 
 revision = "f35b2f12e9dc"
-down_revision = "53c5c7dc5baf"
+down_revision = "e6f4f3021f2b"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- point the provider credentials migration to the latest parent revision so it extends the main branch
- update the migration docstring to reflect the new parent revision

## Testing
- `alembic heads`
- `APP_SECRET=secret DATABASE_URL=sqlite:///./alembic.db REDIS_URL=redis://localhost:6379/0 CELERY_BROKER_URL=redis://localhost:6379/0 CELERY_RESULT_BACKEND=redis://localhost:6379/0 QB_URL=http://example.com QB_USER=user QB_PASS=pass PYTHONPATH=/workspace/Phelia/apps/api alembic upgrade head` *(fails: existing migration e6f4f3021f2b raises KeyError for provider_slug when running against a fresh SQLite database)*