### PR TITLE
Normalize search endpoint results for DiscoverItem payload

### DIFF
--- a/apps/api/app/api/v1/endpoints/search.py
+++ b/apps/api/app/api/v1/endpoints/search.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+import hashlib
+from typing import Any, Iterable, Literal
 
 from fastapi import APIRouter, Depends, Query
 
+from app.schemas.discover import DiscoverItem, SearchResponse
+from app.schemas.media import EnrichedCard
 from app.services.jackett_adapter import JackettAdapter
 
 
@@ -16,15 +19,276 @@ def get_adapter() -> JackettAdapter:
     return JackettAdapter()
 
 
-@router.get("")
+def _ensure_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        if isinstance(value, float):
+            if value.is_integer():
+                return str(int(value))
+            return f"{value:.6g}"
+        return str(value)
+    return str(value)
+
+
+def _ensure_int(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+        try:
+            return int(trimmed)
+        except ValueError:
+            try:
+                as_float = float(trimmed)
+            except ValueError:
+                return None
+            if as_float.is_integer():
+                return int(as_float)
+    return None
+
+
+def _first_str(*values: Any) -> str | None:
+    for value in values:
+        text = _ensure_str(value)
+        if text:
+            return text
+    return None
+
+
+def _extract_genres(details: dict[str, Any]) -> list[str]:
+    genres: list[str] = []
+    tmdb = details.get("tmdb")
+    if isinstance(tmdb, dict):
+        extra = tmdb.get("extra")
+        raw = None
+        if isinstance(extra, dict):
+            raw = extra.get("tmdb")
+        if raw is None:
+            raw = tmdb.get("genres")
+        if isinstance(raw, dict):
+            raw = raw.get("genres")
+        if isinstance(raw, Iterable):
+            for entry in raw:
+                name = None
+                if isinstance(entry, dict):
+                    name = entry.get("name")
+                elif isinstance(entry, str):
+                    name = entry
+                if isinstance(name, str) and name.strip():
+                    genres.append(name.strip())
+    tags = details.get("tags")
+    if isinstance(tags, Iterable) and not isinstance(tags, (str, bytes)):
+        for entry in tags:
+            name = _ensure_str(entry)
+            if name:
+                genres.append(name)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for genre in genres:
+        key = genre.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(genre)
+    return deduped
+
+
+def _extract_rating(details: dict[str, Any]) -> float | None:
+    omdb = details.get("omdb")
+    if isinstance(omdb, dict):
+        rating = omdb.get("imdbRating") or omdb.get("rating")
+        if isinstance(rating, (int, float)):
+            return float(rating)
+        if isinstance(rating, str):
+            try:
+                return float(rating)
+            except ValueError:
+                pass
+    return None
+
+
+def _select_identifier(card: EnrichedCard, kind: str, details: dict[str, Any]) -> str:
+    ids = card.ids or {}
+    preferred_keys: list[str] = []
+    if kind in {"movie", "tv"}:
+        preferred_keys.extend(["tmdb_id", "imdb_id", "tvdb_id", "trakt_id"])
+    elif kind == "album":
+        preferred_keys.extend(
+            [
+                "mb_release_group_id",
+                "mb_release_id",
+                "discogs_id",
+                "mb_album_id",
+            ]
+        )
+    for key in preferred_keys:
+        candidate = _ensure_str(ids.get(key))
+        if candidate:
+            return candidate
+    for value in ids.values():
+        candidate = _ensure_str(value)
+        if candidate:
+            return candidate
+
+    tmdb = details.get("tmdb") if isinstance(details, dict) else None
+    if isinstance(tmdb, dict):
+        for key in ("tmdb_id", "imdb_id"):
+            candidate = _ensure_str(tmdb.get(key))
+            if candidate:
+                return candidate
+
+    musicbrainz = details.get("musicbrainz") if isinstance(details, dict) else None
+    if isinstance(musicbrainz, dict):
+        candidate = _ensure_str(musicbrainz.get("id") or musicbrainz.get("mbid"))
+        if candidate:
+            return candidate
+
+    discogs = details.get("discogs") if isinstance(details, dict) else None
+    if isinstance(discogs, dict):
+        candidate = _ensure_str(discogs.get("id"))
+        if candidate:
+            return candidate
+
+    jackett = details.get("jackett") if isinstance(details, dict) else None
+    if isinstance(jackett, dict):
+        for key in ("guid", "magnet", "url"):
+            candidate = _ensure_str(jackett.get(key))
+            if candidate:
+                digest = hashlib.sha1(candidate.encode("utf-8"), usedforsecurity=False)
+                return digest.hexdigest()
+
+    fallback_source = "||".join(
+        value
+        for value in [kind, card.title, _ensure_str(jackett.get("title") if isinstance(jackett, dict) else None)]
+        if value
+    )
+    if not fallback_source:
+        fallback_source = f"{kind}:{card.title or 'unknown'}"
+    digest = hashlib.sha1(fallback_source.encode("utf-8"), usedforsecurity=False)
+    return digest.hexdigest()
+
+
+def _card_to_discover_item(card: EnrichedCard) -> DiscoverItem | None:
+    media_map = {"movie": "movie", "tv": "tv", "music": "album"}
+    kind = media_map.get(card.media_type)
+    if kind is None:
+        return None
+
+    details = card.details if isinstance(card.details, dict) else {}
+    parsed = card.parsed if isinstance(card.parsed, dict) else {}
+    images = details.get("images") if isinstance(details.get("images"), dict) else {}
+    tmdb = details.get("tmdb") if isinstance(details.get("tmdb"), dict) else {}
+    discogs = details.get("discogs") if isinstance(details.get("discogs"), dict) else {}
+    musicbrainz = details.get("musicbrainz") if isinstance(details.get("musicbrainz"), dict) else {}
+    jackett = details.get("jackett") if isinstance(details.get("jackett"), dict) else {}
+
+    title = _first_str(
+        tmdb.get("title"),
+        tmdb.get("name"),
+        discogs.get("title"),
+        musicbrainz.get("title"),
+        parsed.get("album"),
+        card.title,
+    ) or "Untitled"
+
+    subtitle: str | None = None
+    if kind == "album":
+        subtitle = _first_str(parsed.get("artist"), musicbrainz.get("artist"), details.get("artist"))
+    elif kind == "tv":
+        season = _ensure_int(parsed.get("season"))
+        episode = _ensure_int(parsed.get("episode"))
+        if season is not None and episode is not None:
+            subtitle = f"S{season:02d}E{episode:02d}"
+        elif season is not None:
+            subtitle = f"Season {season}"
+
+    year = _ensure_int(parsed.get("year"))
+    if year is None:
+        year = _ensure_int(tmdb.get("year"))
+    if year is None and isinstance(musicbrainz.get("first_release_date"), str):
+        year = _ensure_int(musicbrainz["first_release_date"][:4])
+    if year is None:
+        year = _ensure_int(discogs.get("year"))
+
+    poster = _first_str(
+        images.get("poster"),
+        images.get("primary"),
+        tmdb.get("poster"),
+        discogs.get("cover_image"),
+    )
+    backdrop = _first_str(images.get("backdrop"), tmdb.get("backdrop"))
+
+    rating = _extract_rating(details)
+    genres = _extract_genres(details)
+
+    badges: list[str] = []
+    if card.needs_confirmation:
+        badges.append("needs_confirmation")
+
+    meta: dict[str, Any] = {
+        "confidence": card.confidence,
+        "needs_confirmation": card.needs_confirmation,
+        "reasons": list(card.reasons),
+        "providers": [provider.model_dump() for provider in card.providers],
+        "ids": card.ids or None,
+        "parsed": card.parsed,
+        "jackett": jackett or None,
+        "source_title": card.title,
+        "source_kind": card.media_type,
+    }
+
+    # Prune empty entries to keep payload compact.
+    meta = {key: value for key, value in meta.items() if value not in (None, {}, [])}
+
+    identifier = _select_identifier(card, kind, details)
+
+    return DiscoverItem(
+        kind=kind,
+        id=identifier,
+        title=title,
+        subtitle=subtitle,
+        year=year,
+        poster=poster,
+        backdrop=backdrop,
+        rating=rating,
+        genres=genres,
+        badges=badges,
+        meta=meta or None,
+    )
+
+
+@router.get("", response_model=SearchResponse)
 async def search(
     q: str = Query(..., min_length=2, alias="q"),
     limit: int = Query(40, ge=1, le=100),
     kind: Literal["all", "movie", "tv", "music"] = Query("all"),
+    page: int = Query(1, ge=1),
     adapter: JackettAdapter = Depends(get_adapter),
-) -> dict[str, Any]:
-    cards, meta = await adapter.search_with_metadata(q, limit=limit, kind=kind)
-    payload: dict[str, Any] = {"items": [card.model_dump() for card in cards]}
-    payload.update(meta)
-    return payload
+) -> SearchResponse:
+    fetch_limit = limit * page
+    cards, meta = await adapter.search_with_metadata(q, limit=fetch_limit, kind=kind)
+    items: list[DiscoverItem] = []
+    for card in cards:
+        item = _card_to_discover_item(card)
+        if item is not None:
+            items.append(item)
+
+    start = (page - 1) * limit
+    end = start + limit
+    page_items = items[start:end]
+
+    response_kwargs = {"page": page, "total_pages": page, "items": page_items}
+    response_kwargs.update(meta)
+    return SearchResponse(**response_kwargs)
 

--- a/apps/api/app/schemas/discover.py
+++ b/apps/api/app/schemas/discover.py
@@ -37,3 +37,15 @@ class PaginatedResponse(BaseModel, Generic[T]):
     total_pages: int = Field(ge=1)
     items: list[T] = Field(default_factory=list)
 
+
+class SearchResponse(PaginatedResponse[DiscoverItem]):
+    """Paginated response with optional Jackett metadata for search results."""
+
+    message: str | None = None
+    jackett_ui_url: str | None = None
+    error: str | None = None
+
+    model_config = {
+        "extra": "allow",
+    }
+

--- a/apps/api/tests/test_metadata_search_endpoint.py
+++ b/apps/api/tests/test_metadata_search_endpoint.py
@@ -1,0 +1,113 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api.v1.endpoints.search import get_adapter, router
+from app.schemas.media import EnrichedCard
+
+
+class DummyAdapter:
+    def __init__(self, cards, meta):
+        self.cards = cards
+        self.meta = meta
+        self.calls = []
+
+    async def search_with_metadata(self, query: str, limit: int = 40, kind: str = "all"):
+        self.calls.append((query, limit, kind))
+        return self.cards, self.meta
+
+
+def build_app(adapter: DummyAdapter) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="")
+    app.dependency_overrides[get_adapter] = lambda: adapter
+    return app
+
+
+@pytest.mark.anyio
+async def test_search_transforms_cards():
+    movie_card = EnrichedCard(
+        media_type="movie",
+        confidence=0.92,
+        title="Example Torrent 1080p",
+        ids={"tmdb_id": 123, "imdb_id": "tt123"},
+        details={
+            "tmdb": {
+                "title": "Example Movie",
+                "year": 1999,
+                "poster": "https://images.example/movie.jpg",
+                "backdrop": "https://images.example/movie-bg.jpg",
+            },
+            "images": {
+                "poster": "https://images.example/movie.jpg",
+                "backdrop": "https://images.example/movie-bg.jpg",
+            },
+            "jackett": {
+                "magnet": "magnet:?xt=urn:btih:movie",
+                "indexer": "TrackerOne",
+            },
+        },
+        reasons=["tmdb_match"],
+    )
+
+    album_card = EnrichedCard(
+        media_type="music",
+        confidence=0.81,
+        title="Radiohead - In Rainbows (2007)",
+        parsed={"artist": "Radiohead", "year": 2007},
+        ids={"mb_release_group_id": "rg-1"},
+        details={
+            "musicbrainz": {
+                "id": "rg-1",
+                "first_release_date": "2007-10-10",
+                "title": "In Rainbows",
+            },
+            "discogs": {
+                "id": 55,
+                "title": "In Rainbows",
+                "cover_image": "https://images.example/in-rainbows.jpg",
+                "year": 2007,
+            },
+            "tags": ["Alternative", "Rock"],
+            "jackett": {
+                "magnet": "magnet:?xt=urn:btih:album",
+                "indexer": "TrackerTwo",
+            },
+        },
+    )
+
+    adapter = DummyAdapter([movie_card, album_card], {"jackett_ui_url": "http://jackett.local"})
+    app = build_app(adapter)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/search", params={"q": "example"})
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["page"] == 1
+    assert payload["total_pages"] == 1
+    assert payload["jackett_ui_url"] == "http://jackett.local"
+
+    assert len(payload["items"]) == 2
+
+    movie = next(item for item in payload["items"] if item["kind"] == "movie")
+    album = next(item for item in payload["items"] if item["kind"] == "album")
+
+    assert movie["id"] == "123"
+    assert movie["title"] == "Example Movie"
+    assert movie["poster"] == "https://images.example/movie.jpg"
+    assert movie["meta"]["confidence"] == pytest.approx(0.92)
+    assert movie["meta"]["jackett"]["magnet"] == "magnet:?xt=urn:btih:movie"
+
+    assert album["id"] == "rg-1"
+    assert album["title"] == "In Rainbows"
+    assert album["subtitle"] == "Radiohead"
+    assert album["poster"] == "https://images.example/in-rainbows.jpg"
+    assert set(album["genres"]) == {"Alternative", "Rock"}
+    assert album["meta"]["source_kind"] == "music"
+    assert album["meta"]["jackett"]["magnet"] == "magnet:?xt=urn:btih:album"
+
+    # Adapter should have been invoked with the requested query and default pagination.
+    assert adapter.calls == [("example", 40, "all")]

--- a/apps/web/src/app/__tests__/TorrentSearchDialog.test.tsx
+++ b/apps/web/src/app/__tests__/TorrentSearchDialog.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TorrentSearchDialog from "@/app/components/TorrentSearchDialog";
-import type { JackettSearchItem } from "@/app/lib/types";
+import type { SearchResultItem } from "@/app/lib/types";
 import { renderWithProviders } from "@/app/test-utils";
 
 const { mutateAsync, resetMock, setOpenMock } = vi.hoisted(() => ({
@@ -10,12 +10,12 @@ const { mutateAsync, resetMock, setOpenMock } = vi.hoisted(() => ({
   setOpenMock: vi.fn(),
 }));
 
-const mockResult: JackettSearchItem = {
-  media_type: "movie",
-  confidence: 0.87,
+const mockResult: SearchResultItem = {
+  id: "example",
+  kind: "movie",
   title: "Example Torrent",
-  ids: {},
-  details: {
+  meta: {
+    confidence: 0.87,
     jackett: {
       magnet: "magnet:?xt=urn:btih:example",
       url: "https://example.com/torrent",
@@ -26,10 +26,11 @@ const mockResult: JackettSearchItem = {
       leechers: 3,
       tracker: "ExampleTracker",
     },
+    providers: [],
+    reasons: [],
+    needs_confirmation: false,
+    source_kind: "movie",
   },
-  providers: [],
-  reasons: [],
-  needs_confirmation: false,
 };
 
 const mockTorrentState = {

--- a/apps/web/src/app/lib/api.ts
+++ b/apps/web/src/app/lib/api.ts
@@ -5,7 +5,6 @@ import type {
   DiscoverItem,
   DiscoverParams,
   DownloadItem,
-  JackettSearchResponse,
   LibraryItemSummary,
   ListMutationInput,
   MetadataProviderSlug,
@@ -15,6 +14,7 @@ import type {
   ProviderSettingsApiResponse,
   ProviderSettingUpdateRequest,
   SearchParams,
+  SearchResponse,
 } from './types';
 
 type QueryRecordValue = string | number | boolean | null | undefined;
@@ -116,7 +116,7 @@ export function useSearch(params: SearchParams) {
     queryKey: ['search', params],
     queryFn: ({ pageParam = 1, queryKey }) => {
       const [, keyParams] = queryKey as SearchQueryKey;
-      return http<PaginatedResponse<DiscoverItem>>('search', {
+      return http<SearchResponse>('search', {
         query: { ...keyParams, page: pageParam },
       });
     },
@@ -268,7 +268,7 @@ export function useUpdateProviderSetting() {
 
 export function fetchJackettSearch(query: string, options?: { limit?: number }) {
   const limit = options?.limit;
-  return http<JackettSearchResponse>('search', {
+  return http<SearchResponse>('search', {
     query: {
       q: query,
       ...(typeof limit === 'number' ? { limit } : {}),

--- a/apps/web/src/app/lib/types.ts
+++ b/apps/web/src/app/lib/types.ts
@@ -74,28 +74,31 @@ export interface JackettTorrentDetails {
   title?: string | null;
 }
 
-export interface JackettSearchItem {
-  media_type: 'music' | 'movie' | 'tv' | 'other';
-  confidence: number;
-  title: string;
+export interface SearchResultMeta {
+  jackett?: JackettTorrentDetails;
+  confidence?: number;
+  needs_confirmation?: boolean;
+  reasons?: string[];
+  providers?: EnrichedProvider[];
+  ids?: Record<string, unknown>;
   parsed?: Record<string, unknown> | null;
-  ids: Record<string, unknown>;
-  details: Record<string, unknown> & { jackett?: JackettTorrentDetails };
-  providers: EnrichedProvider[];
-  reasons: string[];
-  needs_confirmation: boolean;
+  source_title?: string;
+  source_kind?: 'music' | 'movie' | 'tv' | 'other';
+  [key: string]: unknown;
 }
 
-export interface JackettSearchResponseMeta {
+export interface SearchResultItem extends DiscoverItem {
+  meta?: SearchResultMeta;
+}
+
+export interface SearchResponseMeta {
   message?: string;
   jackett_ui_url?: string;
   error?: string;
   [key: string]: unknown;
 }
 
-export interface JackettSearchResponse extends JackettSearchResponseMeta {
-  items: JackettSearchItem[];
-}
+export interface SearchResponse extends PaginatedResponse<SearchResultItem>, SearchResponseMeta {}
 
 export interface ExternalLink {
   label: string;

--- a/apps/web/src/app/stores/torrent-search.ts
+++ b/apps/web/src/app/stores/torrent-search.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { fetchJackettSearch } from '@/app/lib/api';
-import type { JackettSearchItem, MediaKind } from '@/app/lib/types';
+import type { MediaKind, SearchResultItem } from '@/app/lib/types';
 
 interface TorrentSearchItemContext {
   id?: string;
@@ -12,7 +12,7 @@ interface TorrentSearchItemContext {
 interface TorrentSearchState {
   open: boolean;
   isLoading: boolean;
-  results: JackettSearchItem[];
+  results: SearchResultItem[];
   message?: string;
   jackettUiUrl?: string;
   error?: string;


### PR DESCRIPTION
## Summary
- add a transformer for metadata search results that normalizes `EnrichedCard` objects into `DiscoverItem` payloads with stable identifiers
- extend the search response schema and adjust API search handling to emit the normalized items along with Jackett metadata
- update web client types, torrent search UI, and tests to consume the new search payload shape and avoid undefined detail routes

## Testing
- pytest *(fails: docker binary unavailable for qbittorrent integration suite)*
- pnpm --dir apps/web test *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d099104a688329b067aae3a7b607fb