### PR TITLE
feat: add unified discovery service

### DIFF
--- a/apps/api/app/api/v1/endpoints/meta.py
+++ b/apps/api/app/api/v1/endpoints/meta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Iterable, Literal
 
 from fastapi import APIRouter, HTTPException, Query
@@ -511,12 +512,28 @@ async def lookup(body: LookupRequest) -> dict[str, Any]:
 
 @public_router.get("/providers/status")
 def providers_status() -> dict[str, Any]:
+    discovery = {
+        "lastfm": bool(os.getenv("LASTFM_API_KEY")),
+        "deezer": os.getenv("DEEZER_ENABLED", "true").lower() == "true",
+        "itunes": os.getenv("ITUNES_ENABLED", "true").lower() == "true",
+        "musicbrainz": os.getenv("MUSICBRAINZ_ENABLED", "true").lower() == "true",
+        "listenbrainz": (
+            os.getenv("LISTENBRAINZ_ENABLED", "false").lower() == "true"
+            and bool(os.getenv("LISTENBRAINZ_TOKEN"))
+        ),
+        "spotify": (
+            os.getenv("SPOTIFY_ENABLED", "false").lower() == "true"
+            and bool(os.getenv("SPOTIFY_CLIENT_ID"))
+            and bool(os.getenv("SPOTIFY_CLIENT_SECRET"))
+        ),
+    }
     return {
         "tmdb": runtime_settings.tmdb_enabled,
         "omdb": runtime_settings.omdb_enabled,
         "discogs": runtime_settings.discogs_enabled,
         "lastfm": runtime_settings.lastfm_enabled,
         "musicbrainz": bool(settings.MB_USER_AGENT),
+        "discovery": discovery,
     }
 
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -10,6 +10,7 @@ from app.db.init_db import init_db
 from app.db.session import session_scope
 from app.routers import health, auth, downloads, trackers
 from app.api.routes import discovery as discovery_routes
+from phelia.routers import discovery as discovery_router
 from app.api.v1.endpoints import discover as discover_endpoints
 from app.api.v1.endpoints import meta as meta_endpoints
 from app.api.v1.endpoints import search as metadata_search
@@ -42,6 +43,7 @@ app.include_router(metadata_search.router, prefix="/api/v1")
 app.include_router(meta_endpoints.public_router, prefix="/api/v1/meta")
 app.include_router(discover_endpoints.router, prefix="/api/v1")
 app.include_router(discovery_routes.router)
+app.include_router(discovery_router.router, prefix="/discovery", tags=["discovery"])
 app.include_router(index_endpoints.router, prefix="/api/v1/index")
 app.include_router(capabilities_endpoints.router, prefix="/api/v1")
 app.include_router(library_endpoints.router, prefix="/api/v1")

--- a/apps/api/phelia/__init__.py
+++ b/apps/api/phelia/__init__.py
@@ -1,0 +1,5 @@
+"""Phelia backend extension package."""
+
+__all__ = [
+    "discovery",
+]

--- a/apps/api/phelia/discovery/__init__.py
+++ b/apps/api/phelia/discovery/__init__.py
@@ -1,0 +1,5 @@
+"""Unified discovery service for Phelia."""
+
+from . import cache, models, service
+
+__all__ = ["cache", "models", "service"]

--- a/apps/api/phelia/discovery/cache.py
+++ b/apps/api/phelia/discovery/cache.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+
+_CACHE_PREFIX = "discovery"
+_redis_client: redis.Redis | None = None
+
+
+def _ensure_client() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(settings.REDIS_URL)
+    return _redis_client
+
+
+def _ttl() -> int:
+    raw = os.getenv("DISCOVERY_CACHE_TTL_SECONDS")
+    if raw and raw.isdigit():
+        return int(raw)
+    return int(os.getenv("DISCOVERY_CACHE_TTL", "3600"))
+
+
+def build_cache_key(provider: str, fn: str, payload: dict[str, Any]) -> str:
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    h = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+    return f"{_CACHE_PREFIX}:{provider}:{fn}:{h}"
+
+
+async def cache_get_json(key: str) -> Any:
+    client = _ensure_client()
+    raw = await client.get(key)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+async def cache_set_json(key: str, value: Any, ttl: int | None = None) -> None:
+    client = _ensure_client()
+    payload = json.dumps(value)
+    expire = ttl if ttl is not None else _ttl()
+    await client.set(key, payload, ex=expire)
+
+
+async def reset_cache(client: redis.Redis | None = None) -> None:
+    global _redis_client
+    if client is None:
+        client = _redis_client
+    if client:
+        await client.close()
+    _redis_client = None

--- a/apps/api/phelia/discovery/models.py
+++ b/apps/api/phelia/discovery/models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+Source = Literal[
+    "lastfm",
+    "deezer",
+    "itunes",
+    "musicbrainz",
+    "listenbrainz",
+    "spotify",
+]
+
+
+class AlbumItem(BaseModel):
+    id: str
+    canonical_key: str
+    source: Source
+    title: str
+    artist: str
+    release_date: Optional[str] = None
+    cover_url: Optional[HttpUrl] = None
+    source_url: Optional[HttpUrl] = None
+    tags: List[str] = Field(default_factory=list)
+    market: Optional[str] = None
+    score: Optional[float] = None
+    preview_url: Optional[HttpUrl] = None
+    extra: Dict[str, str] = Field(default_factory=dict)
+
+
+class DiscoveryResponse(BaseModel):
+    provider: Source
+    items: List[AlbumItem] = Field(default_factory=list)
+
+
+class ProvidersStatus(BaseModel):
+    lastfm: bool
+    deezer: bool
+    itunes: bool
+    musicbrainz: bool
+    listenbrainz: bool
+    spotify: bool

--- a/apps/api/phelia/discovery/providers/base.py
+++ b/apps/api/phelia/discovery/providers/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import abc
+from typing import List, Optional
+
+from ..models import AlbumItem, DiscoveryResponse
+
+
+class Provider(abc.ABC):
+    name: str
+
+    @abc.abstractmethod
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError

--- a/apps/api/phelia/discovery/providers/deezer.py
+++ b/apps/api/phelia/discovery/providers/deezer.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..models import AlbumItem, DiscoveryResponse
+from .base import Provider
+
+DEEZER_API_ROOT = "https://api.deezer.com"
+COUNTRY_MAP = {"US": 2, "GB": 4, "FR": 0, "DE": 3, "GE": 82}
+
+
+class DeezerProvider(Provider):
+    name = "deezer"
+
+    def __init__(self) -> None:
+        self.timeout = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "8"))
+
+    async def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        retries = 2
+        delay = 0.5
+        last_error: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.get(f"{DEEZER_API_ROOT}{path}", params=params)
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt >= retries:
+                    break
+                await asyncio.sleep(delay + random.uniform(0, 0.3))
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    def _canonical_key(self, artist: str, title: str, release_date: str | None) -> str:
+        artist_key = _slugify(artist)
+        title_key = _slugify(title)
+        year = (release_date or "")[:4]
+        return f"{artist_key}::{title_key}::{year}"
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        market = (market or os.getenv("DISCOVERY_DEFAULT_MARKET", "US")).upper()
+        country_id = COUNTRY_MAP.get(market)
+        path = f"/chart/{country_id}/albums" if country_id is not None else "/chart/albums"
+        payload = await self._get(path, params={"limit": limit})
+        data = payload.get("data", [])
+        items: List[AlbumItem] = []
+        for entry in data[:limit]:
+            artist = (entry.get("artist") or {}).get("name") or ""
+            title = entry.get("title") or ""
+            if not artist or not title:
+                continue
+            items.append(
+                AlbumItem(
+                    id=str(entry.get("id")),
+                    canonical_key=self._canonical_key(artist, title, entry.get("release_date")),
+                    source="deezer",
+                    title=title,
+                    artist=artist,
+                    release_date=entry.get("release_date"),
+                    cover_url=entry.get("cover_medium") or entry.get("cover"),
+                    source_url=entry.get("link"),
+                    market=market,
+                    score=float(entry.get("position")) if entry.get("position") else None,
+                    preview_url=entry.get("preview"),
+                )
+            )
+        return DiscoveryResponse(provider="deezer", items=items)
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        # Deezer does not expose a dedicated new releases endpoint; reuse charts
+        return await self.charts(market=market, limit=limit)
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        payload = await self._get("/search/album", params={"q": query, "limit": limit})
+        data = payload.get("data", [])
+        items: List[AlbumItem] = []
+        for entry in data[:limit]:
+            artist = (entry.get("artist") or {}).get("name") or ""
+            title = entry.get("title") or ""
+            if not artist or not title:
+                continue
+            items.append(
+                AlbumItem(
+                    id=str(entry.get("id")),
+                    canonical_key=self._canonical_key(artist, title, entry.get("release_date")),
+                    source="deezer",
+                    title=title,
+                    artist=artist,
+                    release_date=entry.get("release_date"),
+                    cover_url=entry.get("cover_medium") or entry.get("cover"),
+                    source_url=entry.get("link"),
+                    preview_url=entry.get("preview"),
+                )
+            )
+        return DiscoveryResponse(provider="deezer", items=items)
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned: List[str] = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")

--- a/apps/api/phelia/discovery/providers/itunes.py
+++ b/apps/api/phelia/discovery/providers/itunes.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..models import AlbumItem, DiscoveryResponse
+from .base import Provider
+
+ITUNES_API_ROOT = "https://itunes.apple.com"
+
+
+class ITunesProvider(Provider):
+    name = "itunes"
+
+    def __init__(self) -> None:
+        self.timeout = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "8"))
+
+    async def _get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        retries = 2
+        delay = 0.5
+        last_error: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.get(f"{ITUNES_API_ROOT}{path}", params=params)
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt >= retries:
+                    break
+                await asyncio.sleep(delay + random.uniform(0, 0.3))
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        payload = await self._get(
+            "/search",
+            {
+                "term": query,
+                "entity": "album",
+                "limit": limit,
+                "media": "music",
+            },
+        )
+        results = payload.get("results", [])
+        items: List[AlbumItem] = []
+        for entry in results[:limit]:
+            artist = entry.get("artistName") or ""
+            title = entry.get("collectionName") or ""
+            if not artist or not title:
+                continue
+            release_date = entry.get("releaseDate")
+            items.append(
+                AlbumItem(
+                    id=str(entry.get("collectionId") or entry.get("collectionViewUrl") or f"{artist}-{title}"),
+                    canonical_key=_canonical_key(artist, title, release_date),
+                    source="itunes",
+                    title=title,
+                    artist=artist,
+                    release_date=release_date[:10] if isinstance(release_date, str) else release_date,
+                    cover_url=entry.get("artworkUrl100"),
+                    source_url=entry.get("collectionViewUrl"),
+                    market=entry.get("country"),
+                    preview_url=entry.get("previewUrl"),
+                )
+            )
+        return DiscoveryResponse(provider="itunes", items=items)
+
+    async def lookup_album(self, artist: str, title: str, limit: int = 5) -> List[AlbumItem]:
+        query = f"{artist} {title}".strip()
+        response = await self.search_albums(query=query, limit=limit)
+        return response.items
+
+
+def _canonical_key(artist: str, title: str, release: Optional[str]) -> str:
+    artist_key = _slugify(artist)
+    title_key = _slugify(title)
+    year = (release or "")[:4]
+    return f"{artist_key}::{title_key}::{year}"
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned: List[str] = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")

--- a/apps/api/phelia/discovery/providers/lastfm.py
+++ b/apps/api/phelia/discovery/providers/lastfm.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..models import AlbumItem, DiscoveryResponse
+from .base import Provider
+
+LASTFM_API_ROOT = "https://ws.audioscrobbler.com/2.0/"
+
+
+class LastFMProvider(Provider):
+    name = "lastfm"
+
+    def __init__(self) -> None:
+        api_key = os.getenv("LASTFM_API_KEY")
+        if not api_key:
+            raise RuntimeError("LASTFM_API_KEY missing")
+        self.api_key = api_key
+        self.timeout = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "8"))
+
+    async def _request(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        params = {**params, "api_key": self.api_key, "format": "json"}
+        retries = 2
+        delay = 0.5
+        last_error: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.get(LASTFM_API_ROOT, params=params)
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt >= retries:
+                    break
+                jitter = random.uniform(0, 0.3)
+                await asyncio.sleep(delay + jitter)
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    @staticmethod
+    def _canonical_key(artist: str, title: str, release: str | None = None) -> str:
+        artist_key = _slugify(artist)
+        title_key = _slugify(title)
+        year = (release or "")[:4]
+        return f"{artist_key}::{title_key}::{year}"
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        data = await self._request(
+            {
+                "method": "tag.gettopalbums",
+                "tag": tag,
+                "limit": limit,
+            }
+        )
+        albums = data.get("albums", {}).get("album", [])
+        items: List[AlbumItem] = []
+        for album in albums[:limit]:
+            artist = (album.get("artist") or {}).get("name") or ""
+            title = album.get("name") or ""
+            if not artist or not title:
+                continue
+            mbid = album.get("mbid") or album.get("url")
+            images = album.get("image") or []
+            cover = None
+            for img in reversed(images):
+                if img.get("#text"):
+                    cover = img.get("#text")
+                    break
+            items.append(
+                AlbumItem(
+                    id=str(mbid),
+                    canonical_key=self._canonical_key(artist, title, album.get("releasedate")),
+                    source="lastfm",
+                    title=title,
+                    artist=artist,
+                    release_date=(album.get("releasedate") or "").strip() or None,
+                    cover_url=cover,
+                    source_url=album.get("url"),
+                    tags=[tag],
+                    score=float(album.get("playcount")) if album.get("playcount") else None,
+                )
+            )
+        return DiscoveryResponse(provider="lastfm", items=items)
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        data = await self._request(
+            {
+                "method": "album.search",
+                "album": query,
+                "limit": limit,
+            }
+        )
+        results = data.get("results", {}).get("albummatches", {}).get("album", [])
+        items: List[AlbumItem] = []
+        for album in results[:limit]:
+            artist = album.get("artist") or ""
+            title = album.get("name") or ""
+            if not artist or not title:
+                continue
+            items.append(
+                AlbumItem(
+                    id=album.get("mbid") or album.get("url") or f"{artist}-{title}",
+                    canonical_key=self._canonical_key(artist, title, None),
+                    source="lastfm",
+                    title=title,
+                    artist=artist,
+                    source_url=album.get("url"),
+                    cover_url=album.get("image", [{}])[-1].get("#text") if album.get("image") else None,
+                )
+            )
+        return DiscoveryResponse(provider="lastfm", items=items)
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")

--- a/apps/api/phelia/discovery/providers/listenbrainz.py
+++ b/apps/api/phelia/discovery/providers/listenbrainz.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from ..models import DiscoveryResponse
+from .base import Provider
+
+
+class ListenBrainzProvider(Provider):
+    name = "listenbrainz"
+
+    def __init__(self) -> None:
+        enabled = os.getenv("LISTENBRAINZ_ENABLED", "false").lower() == "true"
+        token = os.getenv("LISTENBRAINZ_TOKEN")
+        if not enabled or not token:
+            raise RuntimeError("ListenBrainz disabled")
+        self.token = token
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError

--- a/apps/api/phelia/discovery/providers/musicbrainz.py
+++ b/apps/api/phelia/discovery/providers/musicbrainz.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Dict, List, Optional
+
+import httpx
+
+from ..models import AlbumItem, DiscoveryResponse
+from .base import Provider
+
+MB_API_ROOT = "https://musicbrainz.org/ws/2"
+MB_USER_AGENT = os.getenv("MB_USER_AGENT", "Phelia/1.0 (https://example.local)")
+_RATE_LIMIT = 1.0  # one request per second
+_last_request = 0.0
+_lock = asyncio.Lock()
+
+
+async def _rate_limit_wait() -> None:
+    global _last_request
+    async with _lock:
+        now = time.monotonic()
+        delta = now - _last_request
+        if delta < 1 / _RATE_LIMIT:
+            await asyncio.sleep((1 / _RATE_LIMIT) - delta)
+        _last_request = time.monotonic()
+
+
+class MusicBrainzProvider(Provider):
+    name = "musicbrainz"
+
+    def __init__(self) -> None:
+        self.timeout = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "8"))
+
+    async def _get(self, path: str, params: Dict[str, str]) -> Dict[str, object]:
+        await _rate_limit_wait()
+        headers = {"User-Agent": MB_USER_AGENT}
+        async with httpx.AsyncClient(timeout=self.timeout, headers=headers) as client:
+            resp = await client.get(f"{MB_API_ROOT}{path}", params=params)
+        if resp.status_code == 503:
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after and retry_after.isdigit():
+                await asyncio.sleep(int(retry_after))
+            return {}
+        resp.raise_for_status()
+        return resp.json()
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        params = {
+            "query": query,
+            "fmt": "json",
+            "limit": str(limit),
+            "type": "release-group",
+        }
+        data = await self._get("/release-group", params)
+        groups = data.get("release-groups", []) if isinstance(data, dict) else []
+        items: List[AlbumItem] = []
+        for entry in groups[:limit]:
+            title = entry.get("title")
+            artist_credit = entry.get("artist-credit") or []
+            artist = ""
+            if artist_credit:
+                artist = artist_credit[0].get("name", "")
+            if not title or not artist:
+                continue
+            release_date = entry.get("first-release-date")
+            items.append(
+                AlbumItem(
+                    id=str(entry.get("id")),
+                    canonical_key=_canonical_key(artist, title, release_date),
+                    source="musicbrainz",
+                    title=title,
+                    artist=artist,
+                    release_date=release_date,
+                    tags=[tag.get("name") for tag in entry.get("tags", []) if tag.get("name")],
+                    source_url=f"https://musicbrainz.org/release-group/{entry.get('id')}",
+                )
+            )
+        return DiscoveryResponse(provider="musicbrainz", items=items)
+
+    async def enrich(self, artist: str, title: str) -> Optional[dict[str, Optional[str]]]:
+        params = {
+            "query": f"artist:{artist} AND release:{title}",
+            "fmt": "json",
+            "limit": "1",
+            "type": "release-group",
+        }
+        data = await self._get("/release-group", params)
+        groups = data.get("release-groups", []) if isinstance(data, dict) else []
+        if not groups:
+            return None
+        group = groups[0]
+        release_date = group.get("first-release-date")
+        mbid = group.get("id")
+        cover_url = None
+        if mbid:
+            cover_url = f"https://coverartarchive.org/release-group/{mbid}/front-500"
+        return {
+            "release_date": release_date,
+            "cover_url": cover_url,
+            "source_url": f"https://musicbrainz.org/release-group/{mbid}" if mbid else None,
+        }
+
+
+def _canonical_key(artist: str, title: str, release: Optional[str]) -> str:
+    artist_key = _slugify(artist)
+    title_key = _slugify(title)
+    year = (release or "")[:4]
+    return f"{artist_key}::{title_key}::{year}"
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned: List[str] = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")

--- a/apps/api/phelia/discovery/providers/spotify.py
+++ b/apps/api/phelia/discovery/providers/spotify.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import random
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ..models import AlbumItem, DiscoveryResponse
+from .base import Provider
+
+SPOTIFY_API_ROOT = "https://api.spotify.com/v1"
+SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
+_token_cache: dict[str, tuple[str, float]] = {}
+
+
+class SpotifyProvider(Provider):
+    name = "spotify"
+
+    def __init__(self) -> None:
+        client_id = os.getenv("SPOTIFY_CLIENT_ID")
+        client_secret = os.getenv("SPOTIFY_CLIENT_SECRET")
+        enabled = os.getenv("SPOTIFY_ENABLED", "false").lower() == "true"
+        if not enabled or not client_id or not client_secret:
+            raise RuntimeError("Spotify disabled")
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "8"))
+
+    async def _get_token(self) -> str:
+        cached = _token_cache.get(self.client_id)
+        if cached and cached[1] > time.time():
+            return cached[0]
+        auth_header = base64.b64encode(f"{self.client_id}:{self.client_secret}".encode()).decode()
+        data = {"grant_type": "client_credentials"}
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(
+                SPOTIFY_TOKEN_URL,
+                data=data,
+                headers={"Authorization": f"Basic {auth_header}"},
+            )
+        resp.raise_for_status()
+        payload = resp.json()
+        token = payload.get("access_token")
+        expires_in = int(payload.get("expires_in", 3600))
+        _token_cache[self.client_id] = (token, time.time() + expires_in - 60)
+        return token
+
+    async def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        token = await self._get_token()
+        retries = 2
+        delay = 0.5
+        last_error: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.get(
+                        f"{SPOTIFY_API_ROOT}{path}",
+                        params=params,
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt >= retries:
+                    break
+                await asyncio.sleep(delay + random.uniform(0, 0.3))
+                delay *= 2
+        if last_error:
+            raise last_error
+        return {}
+
+    async def charts(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def tags(self, *, tag: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+    async def new_releases(self, *, market: Optional[str], limit: int) -> DiscoveryResponse:
+        params = {"country": (market or os.getenv("DISCOVERY_DEFAULT_MARKET", "US")), "limit": limit}
+        payload = await self._get("/browse/new-releases", params=params)
+        albums = (payload.get("albums") or {}).get("items", [])
+        items: List[AlbumItem] = []
+        for album in albums[:limit]:
+            artist_names = ", ".join(artist.get("name") for artist in album.get("artists", []))
+            title = album.get("name") or ""
+            if not artist_names or not title:
+                continue
+            release_date = album.get("release_date")
+            market_code = params.get("country")
+            items.append(
+                AlbumItem(
+                    id=album.get("id"),
+                    canonical_key=_canonical_key(artist_names, title, release_date),
+                    source="spotify",
+                    title=title,
+                    artist=artist_names,
+                    release_date=release_date,
+                    cover_url=(album.get("images") or [{}])[0].get("url"),
+                    source_url=album.get("external_urls", {}).get("spotify"),
+                    market=market_code,
+                    score=0.6,
+                )
+            )
+        return DiscoveryResponse(provider="spotify", items=items)
+
+    async def search_albums(self, *, query: str, limit: int) -> DiscoveryResponse:
+        raise NotImplementedError
+
+
+def _canonical_key(artist: str, title: str, release: Optional[str]) -> str:
+    artist_key = _slugify(artist)
+    title_key = _slugify(title)
+    year = (release or "")[:4]
+    return f"{artist_key}::{title_key}::{year}"
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned: List[str] = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")

--- a/apps/api/phelia/discovery/service.py
+++ b/apps/api/phelia/discovery/service.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterable
+from typing import Dict, List, Optional
+
+from .cache import build_cache_key, cache_get_json, cache_set_json
+from .models import AlbumItem, DiscoveryResponse, ProvidersStatus
+from .providers.base import Provider
+from .providers.deezer import DeezerProvider
+from .providers.itunes import ITunesProvider
+from .providers.lastfm import LastFMProvider
+from .providers.listenbrainz import ListenBrainzProvider
+from .providers.musicbrainz import MusicBrainzProvider
+from .providers.spotify import SpotifyProvider
+
+SOURCE_PRIORITY = {
+    "spotify": 0,
+    "deezer": 1,
+    "lastfm": 2,
+    "itunes": 3,
+    "musicbrainz": 4,
+    "listenbrainz": 5,
+}
+
+_PROVIDER_CACHE: Dict[str, Provider] = {}
+
+
+def _slugify(value: str) -> str:
+    normalized = value.lower().strip()
+    cleaned: List[str] = []
+    prev_dash = False
+    for ch in normalized:
+        if ch.isalnum():
+            cleaned.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                cleaned.append("-")
+                prev_dash = True
+    return "".join(cleaned).strip("-")
+
+
+def _canonical_key(item: AlbumItem) -> str:
+    if item.canonical_key:
+        return item.canonical_key
+    year = (item.release_date or "")[:4]
+    return f"{_slugify(item.artist)}::{_slugify(item.title)}::{year}"
+
+
+def _provider_enabled(name: str) -> bool:
+    env = os.getenv
+    if name == "lastfm":
+        return bool(env("LASTFM_API_KEY"))
+    if name == "deezer":
+        return env("DEEZER_ENABLED", "true").lower() == "true"
+    if name == "itunes":
+        return env("ITUNES_ENABLED", "true").lower() == "true"
+    if name == "musicbrainz":
+        return env("MUSICBRAINZ_ENABLED", "true").lower() == "true"
+    if name == "listenbrainz":
+        enabled = env("LISTENBRAINZ_ENABLED", "false").lower() == "true"
+        return enabled and bool(env("LISTENBRAINZ_TOKEN"))
+    if name == "spotify":
+        enabled = env("SPOTIFY_ENABLED", "false").lower() == "true"
+        return enabled and bool(env("SPOTIFY_CLIENT_ID")) and bool(env("SPOTIFY_CLIENT_SECRET"))
+    return False
+
+
+def _get_provider(name: str) -> Optional[Provider]:
+    if not _provider_enabled(name):
+        return None
+    if name in _PROVIDER_CACHE:
+        return _PROVIDER_CACHE[name]
+    try:
+        if name == "lastfm":
+            provider = LastFMProvider()
+        elif name == "deezer":
+            provider = DeezerProvider()
+        elif name == "itunes":
+            provider = ITunesProvider()
+        elif name == "musicbrainz":
+            provider = MusicBrainzProvider()
+        elif name == "listenbrainz":
+            provider = ListenBrainzProvider()
+        elif name == "spotify":
+            provider = SpotifyProvider()
+        else:
+            return None
+    except Exception:  # noqa: BLE001
+        return None
+    _PROVIDER_CACHE[name] = provider
+    return provider
+
+
+async def _call_provider(provider: Provider, method: str, kwargs: Dict[str, object]) -> List[AlbumItem]:
+    cache_key = build_cache_key(provider.name, method, kwargs)
+    cached = await cache_get_json(cache_key)
+    if cached:
+        response = DiscoveryResponse(**cached)
+        return [AlbumItem(**item) if not isinstance(item, AlbumItem) else item for item in response.items]
+    try:
+        fn = getattr(provider, method)
+        response: DiscoveryResponse = await fn(**kwargs)  # type: ignore[misc]
+    except NotImplementedError:
+        return []
+    except Exception:
+        return []
+    await cache_set_json(cache_key, response.model_dump(mode="json"))
+    return response.items
+
+
+def _merge_items(responses: Iterable[AlbumItem]) -> List[AlbumItem]:
+    merged: Dict[str, AlbumItem] = {}
+    for item in responses:
+        key = _canonical_key(item)
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = item
+            continue
+        merged[key] = _prefer_item(existing, item)
+    return list(merged.values())
+
+
+def _prefer_item(current: AlbumItem, candidate: AlbumItem) -> AlbumItem:
+    chosen = current
+    if (not current.cover_url and candidate.cover_url) or (
+        (current.release_date or "") < (candidate.release_date or "") and candidate.release_date
+    ) or ((current.score or 0.0) < (candidate.score or 0.0)) or (
+        SOURCE_PRIORITY.get(candidate.source, 99) < SOURCE_PRIORITY.get(current.source, 99)
+    ):
+        chosen = candidate
+    base = AlbumItem(**chosen.model_dump())
+    tags = set(current.tags)
+    tags.update(candidate.tags)
+    base.tags = list(tags)
+    if not base.cover_url:
+        base.cover_url = candidate.cover_url or current.cover_url
+    if not base.release_date:
+        base.release_date = candidate.release_date or current.release_date
+    if not base.source_url:
+        base.source_url = candidate.source_url or current.source_url
+    if not base.preview_url:
+        base.preview_url = candidate.preview_url or current.preview_url
+    base.extra = {**current.extra, **candidate.extra, **base.extra}
+    return base
+
+
+async def _enrich_items(items: List[AlbumItem]) -> None:
+    need_itunes = [item for item in items if not item.cover_url][:10]
+    need_mb = [item for item in items if not item.release_date][:10]
+    itunes = _get_provider("itunes")
+    musicbrainz = _get_provider("musicbrainz")
+    if itunes:
+        for item in need_itunes:
+            try:
+                matches = await itunes.lookup_album(item.artist, item.title, limit=3)  # type: ignore[arg-type]
+            except Exception:
+                continue
+            if not matches:
+                continue
+            match = matches[0]
+            if match.cover_url and not item.cover_url:
+                item.cover_url = match.cover_url
+            if match.release_date and not item.release_date:
+                item.release_date = match.release_date
+            if match.source_url and not item.source_url:
+                item.source_url = match.source_url
+    if musicbrainz:
+        for item in need_mb:
+            try:
+                enriched = await musicbrainz.enrich(item.artist, item.title)  # type: ignore[attr-defined]
+            except Exception:
+                continue
+            if not enriched:
+                continue
+            if enriched.get("release_date") and not item.release_date:
+                item.release_date = enriched["release_date"]
+            if enriched.get("cover_url") and not item.cover_url:
+                item.cover_url = enriched["cover_url"]
+            if enriched.get("source_url") and not item.source_url:
+                item.source_url = enriched["source_url"]
+
+
+def _max_limit(limit: int) -> int:
+    max_items = int(os.getenv("DISCOVERY_MAX_ITEMS", "50"))
+    return min(limit, max_items)
+
+
+async def get_charts(*, market: Optional[str], limit: int) -> List[AlbumItem]:
+    limit = _max_limit(limit)
+    market = market or os.getenv("DISCOVERY_DEFAULT_MARKET", "US")
+    tasks: List[asyncio.Task[List[AlbumItem]]] = []
+    for name in ("deezer", "spotify"):
+        provider = _get_provider(name)
+        if not provider:
+            continue
+        tasks.append(asyncio.create_task(_call_provider(provider, "charts", {"market": market, "limit": limit})))
+    results = await asyncio.gather(*tasks) if tasks else []
+    merged = _merge_items(item for group in results for item in group)
+    await _enrich_items(merged)
+    return merged[:limit]
+
+
+async def get_tag(*, tag: str, limit: int) -> List[AlbumItem]:
+    limit = _max_limit(limit)
+    tasks: List[asyncio.Task[List[AlbumItem]]] = []
+    for name in ("lastfm", "listenbrainz"):
+        provider = _get_provider(name)
+        if not provider:
+            continue
+        tasks.append(asyncio.create_task(_call_provider(provider, "tags", {"tag": tag, "limit": limit})))
+    results = await asyncio.gather(*tasks) if tasks else []
+    merged = _merge_items(item for group in results for item in group)
+    await _enrich_items(merged)
+    return merged[:limit]
+
+
+async def get_new_releases(*, market: Optional[str], limit: int) -> List[AlbumItem]:
+    limit = _max_limit(limit)
+    market = market or os.getenv("DISCOVERY_DEFAULT_MARKET", "US")
+    tasks: List[asyncio.Task[List[AlbumItem]]] = []
+    for name in ("spotify", "deezer"):
+        provider = _get_provider(name)
+        if not provider:
+            continue
+        tasks.append(asyncio.create_task(_call_provider(provider, "new_releases", {"market": market, "limit": limit})))
+    results = await asyncio.gather(*tasks) if tasks else []
+    merged = _merge_items(item for group in results for item in group)
+    await _enrich_items(merged)
+    return merged[:limit]
+
+
+async def quick_search(*, query: str, limit: int) -> List[AlbumItem]:
+    limit = _max_limit(limit)
+    tasks: List[asyncio.Task[List[AlbumItem]]] = []
+    for name in ("spotify", "deezer", "lastfm", "itunes", "musicbrainz"):
+        provider = _get_provider(name)
+        if not provider:
+            continue
+        tasks.append(asyncio.create_task(_call_provider(provider, "search_albums", {"query": query, "limit": limit})))
+    results = await asyncio.gather(*tasks) if tasks else []
+    merged = _merge_items(item for group in results for item in group)
+    await _enrich_items(merged)
+    return merged[:limit]
+
+
+async def providers_status() -> ProvidersStatus:
+    return ProvidersStatus(
+        lastfm=_provider_enabled("lastfm"),
+        deezer=_provider_enabled("deezer"),
+        itunes=_provider_enabled("itunes"),
+        musicbrainz=_provider_enabled("musicbrainz"),
+        listenbrainz=_provider_enabled("listenbrainz"),
+        spotify=_provider_enabled("spotify"),
+    )

--- a/apps/api/phelia/routers/__init__.py
+++ b/apps/api/phelia/routers/__init__.py
@@ -1,0 +1,5 @@
+"""Discovery routers for the Phelia backend."""
+
+from . import discovery
+
+__all__ = ["discovery"]

--- a/apps/api/phelia/routers/discovery.py
+++ b/apps/api/phelia/routers/discovery.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Query
+
+from phelia.discovery.models import AlbumItem, ProvidersStatus
+from phelia.discovery.service import (
+    get_charts,
+    get_new_releases,
+    get_tag,
+    providers_status,
+    quick_search,
+)
+
+router = APIRouter()
+
+
+@router.get("/charts", response_model=List[AlbumItem])
+async def charts(market: Optional[str] = Query(default=None), limit: int = 50) -> List[AlbumItem]:
+    return await get_charts(market=market, limit=limit)
+
+
+@router.get("/tags", response_model=List[AlbumItem])
+async def tags(tag: str, limit: int = 50) -> List[AlbumItem]:
+    return await get_tag(tag=tag, limit=limit)
+
+
+@router.get("/new", response_model=List[AlbumItem])
+async def new(market: Optional[str] = Query(default=None), limit: int = 50) -> List[AlbumItem]:
+    return await get_new_releases(market=market, limit=limit)
+
+
+@router.get("/search", response_model=List[AlbumItem])
+async def search(q: str, limit: int = 25) -> List[AlbumItem]:
+    return await quick_search(query=q, limit=limit)
+
+
+@router.get("/providers/status", response_model=ProvidersStatus)
+async def status() -> ProvidersStatus:
+    return await providers_status()

--- a/apps/api/tests/test_discovery_service.py
+++ b/apps/api/tests/test_discovery_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import pytest
+import httpx
+
+from phelia.discovery import cache, service
+
+
+class DummyRedis:
+    def __init__(self) -> None:
+        self.store: Dict[str, str] = {}
+
+    async def get(self, key: str):  # type: ignore[override]
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None):  # type: ignore[override]
+        self.store[key] = value
+
+
+@pytest.fixture(autouse=True)
+async def reset_cache(monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(cache, "_redis_client", dummy, raising=False)
+    monkeypatch.setattr(cache, "_ensure_client", lambda: dummy, raising=False)
+    service._PROVIDER_CACHE.clear()
+    yield
+    service._PROVIDER_CACHE.clear()
+
+
+class MockAsyncClient:
+    def __init__(self, responses: List[Tuple[int, dict]], calls: List[Tuple[str, dict | None]]):
+        self._responses = responses
+        self._calls = calls
+
+    async def __aenter__(self) -> "MockAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+    async def get(self, url: str, params: dict | None = None, **kwargs) -> httpx.Response:  # type: ignore[override]
+        self._calls.append((url, params))
+        if not self._responses:
+            raise AssertionError(f"Unexpected HTTP GET to {url}")
+        status, payload = self._responses.pop(0)
+        request = httpx.Request("GET", url, params=params)
+        return httpx.Response(status, json=payload, request=request)
+
+    async def post(self, url: str, data=None, headers=None, **kwargs):  # type: ignore[override]
+        raise AssertionError("POST not expected in tests")
+
+
+@pytest.mark.anyio
+async def test_get_charts_uses_cache(monkeypatch):
+    monkeypatch.setenv("DEEZER_ENABLED", "true")
+    monkeypatch.delenv("SPOTIFY_ENABLED", raising=False)
+    monkeypatch.delenv("LASTFM_API_KEY", raising=False)
+    responses = [
+        (
+            200,
+            {
+                "data": [
+                    {
+                        "id": 1,
+                        "title": "Test Album",
+                        "artist": {"name": "Example"},
+                        "release_date": "2024-01-01",
+                        "cover": "https://example.com/cover.jpg",
+                        "link": "https://deezer.com/album/1",
+                    }
+                ]
+            },
+        )
+    ]
+    calls: List[Tuple[str, dict | None]] = []
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: MockAsyncClient(responses, calls),
+    )
+
+    first = await service.get_charts(market="US", limit=5)
+    assert len(first) == 1
+    assert calls and calls[0][0].startswith("https://api.deezer.com/chart/2/albums")
+
+    second = await service.get_charts(market="US", limit=5)
+    assert len(second) == 1
+    assert len(calls) == 1
+
+
+@pytest.mark.anyio
+async def test_get_tag_enriches_from_itunes(monkeypatch):
+    monkeypatch.setenv("LASTFM_API_KEY", "key")
+    monkeypatch.setenv("ITUNES_ENABLED", "true")
+    monkeypatch.delenv("DEEZER_ENABLED", raising=False)
+    monkeypatch.delenv("SPOTIFY_ENABLED", raising=False)
+    responses = [
+        (
+            200,
+            {
+                "albums": {
+                    "album": [
+                        {
+                            "name": "Shoegaze Album",
+                            "artist": {"name": "Dream Artist"},
+                            "url": "https://last.fm/album",
+                            "image": [],
+                        }
+                    ]
+                }
+            },
+        ),
+        (
+            200,
+            {
+                "results": [
+                    {
+                        "collectionId": 10,
+                        "collectionName": "Shoegaze Album",
+                        "artistName": "Dream Artist",
+                        "artworkUrl100": "https://example.com/art.jpg",
+                        "releaseDate": "2024-02-02T00:00:00Z",
+                        "collectionViewUrl": "https://itunes.com/album",
+                    }
+                ]
+            },
+        ),
+    ]
+    calls: List[Tuple[str, dict | None]] = []
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: MockAsyncClient(responses, calls),
+    )
+
+    items = await service.get_tag(tag="shoegaze", limit=5)
+    assert len(items) == 1
+    item = items[0]
+    assert str(item.cover_url) == "https://example.com/art.jpg"
+    assert item.release_date == "2024-02-02"
+
+
+@pytest.mark.anyio
+async def test_providers_status_flags(monkeypatch):
+    monkeypatch.setenv("LASTFM_API_KEY", "key")
+    monkeypatch.setenv("DEEZER_ENABLED", "true")
+    monkeypatch.setenv("ITUNES_ENABLED", "true")
+    monkeypatch.setenv("MUSICBRAINZ_ENABLED", "true")
+    monkeypatch.setenv("SPOTIFY_ENABLED", "false")
+    monkeypatch.delenv("SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIFY_CLIENT_SECRET", raising=False)
+
+    status = await service.providers_status()
+    assert status.lastfm is True
+    assert status.deezer is True
+    assert status.spotify is False

--- a/apps/web/src/app/routes/music.tsx
+++ b/apps/web/src/app/routes/music.tsx
@@ -1,264 +1,125 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { toast } from 'sonner';
+import { useEffect, useState } from 'react';
 
-import CatalogGrid from '@/app/components/CatalogGrid';
-import FiltersBar from '@/app/components/FiltersBar';
-import RecommendationsRail from '@/app/components/Rails/RecommendationsRail';
-import { Badge } from '@/app/components/ui/badge';
 import { Skeleton } from '@/app/components/ui/skeleton';
-import { useQueryParams } from '@/app/hooks/useQueryParams';
-import { useDiscover, useSearch } from '@/app/lib/api';
-import { getGenres, getNew, getTop } from '@/app/lib/discovery';
-import type { DiscoverParams, DiscoverItem } from '@/app/lib/types';
-import type { DiscoveryGenre } from '@/app/lib/discovery';
+import type { AlbumItem, DiscoveryProvidersStatus } from '@/app/lib/discovery';
+import {
+  fetchDiscoveryCharts,
+  fetchDiscoveryNew,
+  fetchDiscoveryProviders,
+  fetchDiscoveryTag,
+} from '@/app/lib/discovery';
 
-const DEFAULT_DAYS = 30;
-const DEFAULT_LIMIT = 50;
-
-type MusicBrainzRelease = {
-  mbid?: string;
-  title?: string;
-  artist?: string;
-  firstReleaseDate?: string;
-  primaryType?: string;
-  secondaryTypes?: string[];
-};
-
-type AppleFeedItem = {
-  id?: string;
-  title?: string;
-  artist?: string;
-  url?: string;
-  artwork?: string;
-  releaseDate?: string;
-};
-
-function parseYear(value?: string | null): number | undefined {
-  if (!value) return undefined;
-  const year = Number.parseInt(value.slice(0, 4), 10);
-  return Number.isFinite(year) ? year : undefined;
-}
-
-function mapMusicBrainzItem(item: MusicBrainzRelease, genreLabel: string): DiscoverItem {
-  const badges: string[] = [];
-  if (item.primaryType) {
-    badges.push(item.primaryType);
-  }
-  if (Array.isArray(item.secondaryTypes) && item.secondaryTypes.length) {
-    badges.push(...item.secondaryTypes);
-  }
-  return {
-    kind: 'album',
-    id: item.mbid || `mb:${item.title ?? 'unknown'}:${item.artist ?? 'various'}`,
-    title: item.title ?? 'Untitled Release',
-    subtitle: item.artist ?? genreLabel,
-    year: parseYear(item.firstReleaseDate),
-    badges,
-    meta: {
-      source: 'musicbrainz',
-      mbid: item.mbid,
-      firstReleaseDate: item.firstReleaseDate,
-      primaryType: item.primaryType,
-      secondaryTypes: item.secondaryTypes,
-    },
-  };
-}
-
-function mapAppleItem(item: AppleFeedItem): DiscoverItem {
-  return {
-    kind: 'album',
-    id: item.id ?? `apple:${item.title ?? 'unknown'}:${item.artist ?? 'various'}`,
-    title: item.title ?? 'Untitled Album',
-    subtitle: item.artist ?? undefined,
-    poster: item.artwork ?? undefined,
-    year: parseYear(item.releaseDate),
-    meta: {
-      source: 'apple',
-      url: item.url,
-      releaseDate: item.releaseDate,
-    },
-  };
-}
-
-function GenreButton({ genre, active, onSelect }: { genre: DiscoveryGenre; active: boolean; onSelect: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={active}
-      className={`group flex flex-col justify-between rounded-3xl border p-4 text-left transition hover:border-[color:var(--accent)] hover:shadow-glow ${
-        active ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-foreground' : 'border-border/60 text-muted-foreground'
-      }`}
-    >
-      <span className="text-lg font-semibold text-foreground">{genre.label}</span>
-      <span className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">{genre.key.replace(/-/g, ' ')}</span>
-    </button>
-  );
-}
-
-type FilterState = {
-  sort: NonNullable<DiscoverParams['sort']>;
-  year: string;
-  genre: string;
-  type: DiscoverParams['type'];
-  search: string;
-};
-
-const defaults: FilterState = { sort: 'trending', year: '', genre: '', type: undefined, search: '' };
+const TAGS = ['techno', 'ambient', 'shoegaze', 'hip-hop'];
 
 function MusicPage() {
-  const [filters, setFilters] = useQueryParams<FilterState>(defaults);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-
-  const genresQuery = useQuery({
-    queryKey: ['discovery', 'genres'],
-    queryFn: getGenres,
-    staleTime: 12 * 60 * 60 * 1000,
-  });
-
-  const genres = genresQuery.data ?? [];
+  const [newReleases, setNewReleases] = useState<AlbumItem[] | null>(null);
+  const [charts, setCharts] = useState<AlbumItem[] | null>(null);
+  const [tagShelves, setTagShelves] = useState<Record<string, AlbumItem[]>>({});
+  const [providers, setProviders] = useState<DiscoveryProvidersStatus | null>(null);
 
   useEffect(() => {
-    if (!selectedKey && genres.length) {
-      setSelectedKey(genres[0]?.key ?? null);
-    }
-  }, [genres, selectedKey]);
-
-  const selectedGenre = useMemo<DiscoveryGenre | null>(
-    () => genres.find((genre) => genre.key === selectedKey) ?? null,
-    [genres, selectedKey],
-  );
-
-  const newReleasesQuery = useQuery({
-    queryKey: ['discovery', 'new', selectedGenre?.key, DEFAULT_DAYS, DEFAULT_LIMIT],
-    queryFn: () => getNew(selectedGenre!.key, DEFAULT_DAYS, DEFAULT_LIMIT),
-    enabled: Boolean(selectedGenre?.key),
-    select: (items: MusicBrainzRelease[]) => items.map((item) => mapMusicBrainzItem(item, selectedGenre?.label ?? '')),
-    staleTime: 3 * 60 * 60 * 1000,
-  });
-
-  const mostRecentQuery = useQuery({
-    queryKey: ['discovery', 'top', selectedGenre?.appleGenreId, DEFAULT_LIMIT],
-    queryFn: () => getTop(selectedGenre!.appleGenreId, 'most-recent', 'albums', DEFAULT_LIMIT),
-    enabled: Boolean(selectedGenre?.appleGenreId),
-    select: (items: AppleFeedItem[]) => items.map((item) => mapAppleItem(item)),
-    staleTime: 3 * 60 * 60 * 1000,
-  });
-
-  useEffect(() => {
-    if (newReleasesQuery.error) {
-      toast.error('Unable to load new releases.');
-    }
-  }, [newReleasesQuery.error]);
-
-  useEffect(() => {
-    if (mostRecentQuery.error) {
-      toast.error('Unable to load most recent releases.');
-    }
-  }, [mostRecentQuery.error]);
-  const discoverParams = {
-    sort: filters.sort,
-    year: filters.year || undefined,
-    genre: filters.genre || undefined,
-    type: filters.type,
-  };
-
-  const discoverQuery = useDiscover('album', discoverParams);
-  const searchQuery = useSearch({ q: filters.search ?? '', kind: 'music' });
-
-  const activeQuery = filters.search ? searchQuery : discoverQuery;
-  const items = activeQuery.data?.pages.flatMap((page) => page.items) ?? [];
+    fetchDiscoveryProviders()
+      .then(setProviders)
+      .catch(() => setProviders({
+        lastfm: false,
+        deezer: false,
+        itunes: false,
+        musicbrainz: false,
+        listenbrainz: false,
+        spotify: false,
+      }));
+    fetchDiscoveryNew(undefined, 30)
+      .then(setNewReleases)
+      .catch(() => setNewReleases([]));
+    fetchDiscoveryCharts(undefined, 30)
+      .then(setCharts)
+      .catch(() => setCharts([]));
+    Promise.all(TAGS.map((tag) => fetchDiscoveryTag(tag, 24).then((items) => [tag, items] as const)))
+      .then((entries) => setTagShelves(Object.fromEntries(entries)))
+      .catch(() => setTagShelves({}));
+  }, []);
 
   return (
     <div className="space-y-12">
-      <section className="space-y-6">
-        <h1 className="text-2xl font-semibold text-foreground">Music</h1>
-        <FiltersBar
-          kind="music"
-          filters={filters}
-          onChange={(next) => setFilters({ ...filters, ...next })}
-        />
-        <CatalogGrid
-          items={items}
-          loading={activeQuery.isLoading || activeQuery.isFetching}
-          hasNextPage={Boolean(activeQuery.hasNextPage)}
-          fetchNextPage={activeQuery.fetchNextPage}
-        />
-      </section>
-
-      <section className="space-y-6">
-        <header className="space-y-2">
-          <h2 className="text-xl font-semibold text-foreground">Browse by Genre</h2>
-          <p className="text-sm text-muted-foreground">Discover new releases and trending albums curated by genre.</p>
-        </header>
-
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-foreground">Genres</h3>
-          {selectedGenre ? (
-            <Badge variant="outline" className="bg-background/60 text-xs uppercase tracking-wide">
-              {selectedGenre.label}
-            </Badge>
-          ) : null}
-        </div>
-
-        {genresQuery.isLoading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, index) => (
-              <Skeleton key={index} className="h-24 rounded-3xl" />
-            ))}
-          </div>
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Music Discovery</h1>
+        <p className="text-sm text-muted-foreground">
+          Fresh releases and genre shelves aggregated from Last.fm, Deezer, Spotify, iTunes, and MusicBrainz.
+        </p>
+        {providers ? (
+          <p className="text-xs text-muted-foreground">
+            Providers active: {Object.entries(providers).filter(([, enabled]) => enabled).map(([name]) => name).join(', ') || 'none'}
+          </p>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {genres.map((genre) => (
-              <GenreButton
-                key={genre.key}
-                genre={genre}
-                active={genre.key === selectedKey}
-                onSelect={() => setSelectedKey(genre.key)}
-              />
-            ))}
-          </div>
+          <Skeleton className="h-4 w-40" />
         )}
-      </section>
+      </header>
 
-      {selectedGenre ? (
-        <div className="space-y-10">
-          <section className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-foreground">New Releases</h3>
-              <span className="text-xs text-muted-foreground">MusicBrainz • Last {DEFAULT_DAYS} days</span>
-            </div>
-            {newReleasesQuery.isLoading ? (
-              <Skeleton className="h-52 w-full rounded-3xl" />
-            ) : (
-              <>
-                <RecommendationsRail title="New Releases" items={newReleasesQuery.data ?? []} />
-                {!newReleasesQuery.isLoading && !(newReleasesQuery.data?.length ?? 0) ? (
-                  <p className="text-sm text-muted-foreground">No recent releases found for this genre.</p>
-                ) : null}
-              </>
-            )}
-          </section>
+      <DiscoverySection title="New Releases" subtitle="Cross-provider" items={newReleases} />
+      <DiscoverySection title="Top Albums" subtitle="Charts" items={charts} />
 
-          <section className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-foreground">Most Recent</h3>
-              <span className="text-xs text-muted-foreground">Apple Music RSS</span>
-            </div>
-            {mostRecentQuery.isLoading ? (
-              <Skeleton className="h-52 w-full rounded-3xl" />
-            ) : (
-              <>
-                <RecommendationsRail title="Most Recent" items={mostRecentQuery.data ?? []} />
-                {!mostRecentQuery.isLoading && !(mostRecentQuery.data?.length ?? 0) ? (
-                  <p className="text-sm text-muted-foreground">No trending releases available.</p>
-                ) : null}
-              </>
-            )}
-          </section>
+      {TAGS.map((tag) => (
+        <DiscoverySection
+          key={tag}
+          title={tag.toUpperCase()}
+          subtitle="Tag shelf"
+          items={tagShelves[tag]}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DiscoverySection({
+  title,
+  subtitle,
+  items,
+}: {
+  title: string;
+  subtitle: string;
+  items: AlbumItem[] | null | undefined;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-foreground">{title}</h2>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">{subtitle}</p>
         </div>
-      ) : null}
+      </div>
+      {items === null ? (
+        <Skeleton className="h-48 w-full rounded-3xl" />
+      ) : items && items.length ? (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {items.map((item) => (
+            <AlbumCard key={item.canonical_key} item={item} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No results available right now.</p>
+      )}
+    </section>
+  );
+}
+
+function AlbumCard({ item }: { item: AlbumItem }) {
+  return (
+    <div className="w-40 flex-shrink-0 space-y-2">
+      <div className="h-40 w-40 overflow-hidden rounded-xl bg-muted">
+        {item.cover_url ? (
+          <img src={item.cover_url} alt={item.title} className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">No artwork</div>
+        )}
+      </div>
+      <div className="space-y-1">
+        <p className="truncate text-sm font-semibold text-foreground">{item.title}</p>
+        <p className="truncate text-xs text-muted-foreground">{item.artist}</p>
+        {item.release_date ? (
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{item.release_date}</p>
+        ) : null}
+        <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{item.source}</p>
+      </div>
     </div>
   );
 }

--- a/deploy/env/api.env
+++ b/deploy/env/api.env
@@ -34,3 +34,32 @@ GUNICORN_TIMEOUT=120
 
 # ==== Optional ====
 # LOG_LEVEL=info
+
+# Last.fm
+LASTFM_API_KEY=
+
+# Deezer (public, no key required) — keep for feature flag
+DEEZER_ENABLED=true
+
+# iTunes Search — no key required
+ITUNES_ENABLED=true
+
+# MusicBrainz — respect 1 rps
+MUSICBRAINZ_ENABLED=true
+MB_APP_NAME=phelia
+MB_APP_VERSION=1.0
+
+# ListenBrainz (optional)
+LISTENBRAINZ_ENABLED=false
+LISTENBRAINZ_TOKEN=
+
+# Spotify (optional client credentials)
+SPOTIFY_ENABLED=false
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Discovery defaults
+DISCOVERY_DEFAULT_MARKET=US
+DISCOVERY_CACHE_TTL_SECONDS=3600
+DISCOVERY_HTTP_TIMEOUT=8
+DISCOVERY_MAX_ITEMS=50


### PR DESCRIPTION
## Summary
- add normalized discovery models, caching, provider adapters, and a unifying service to merge results across Last.fm, Deezer, iTunes, MusicBrainz, and Spotify
- expose new FastAPI discovery routes, extend provider status reporting, and wire environment flags for discovery providers
- refresh the music discovery UI and API client to consume the unified endpoints and add coverage for caching and enrichment logic

## Testing
- pytest tests/test_discovery_service.py