### PR TITLE
feat: add plugin-managed settings support

### DIFF
--- a/apps/api/alembic/versions/2b742bd4cfa6_add_plugin_settings_table.py
+++ b/apps/api/alembic/versions/2b742bd4cfa6_add_plugin_settings_table.py
@@ -1,0 +1,32 @@
+"""add plugin settings table
+
+Revision ID: 2b742bd4cfa6
+Revises: f35b2f12e9dc
+Create Date: 2024-07-23 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2b742bd4cfa6"
+down_revision = "f35b2f12e9dc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plugin_settings",
+        sa.Column("plugin_id", sa.String(length=128), nullable=False),
+        sa.Column("key", sa.String(length=128), nullable=False),
+        sa.Column("value_json", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("plugin_id", "key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("plugin_settings")

--- a/apps/api/app/api/v1/endpoints/settings.py
+++ b/apps/api/app/api/v1/endpoints/settings.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.core.runtime_settings import runtime_settings
@@ -11,9 +11,15 @@ from app.schemas.settings import (
     ProviderCredentialPayload,
     ProviderCredentialStatus,
     ProviderCredentialsResponse,
+    PluginSettingsListResponse,
+    PluginSettingsSummary,
+    PluginSettingsUpdatePayload,
+    PluginSettingsValuesResponse,
 )
 from app.services import settings as settings_service
 from app.services.settings import UnsupportedProviderError
+from app.plugins import loader
+from app.services import plugin_settings as plugin_settings_service
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 
@@ -55,3 +61,69 @@ def upsert_provider(
         configured=bool(stored_key),
         masked_api_key=settings_service.mask_api_key(stored_key),
     )
+
+
+@router.get("/plugins", response_model=PluginSettingsListResponse)
+def list_plugin_settings() -> PluginSettingsListResponse:
+    runtimes = loader.list_plugins()
+    plugins: list[PluginSettingsSummary] = []
+    for runtime in runtimes:
+        manifest = runtime.manifest
+        contributes = manifest.contributes_settings
+        if contributes is None:
+            contributes = bool(manifest.settings_schema)
+        plugins.append(
+            PluginSettingsSummary(
+                id=manifest.id,
+                name=manifest.name,
+                contributes_settings=bool(contributes),
+                settings_schema=manifest.settings_schema,
+            )
+        )
+    return PluginSettingsListResponse(plugins=plugins)
+
+
+def _ensure_plugin_runtime(plugin_id: str) -> loader.PluginRuntime:
+    runtime = loader.get_runtime(plugin_id)
+    if runtime is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "plugin_not_found"},
+        )
+    return runtime
+
+
+@router.get("/plugins/{plugin_id}", response_model=PluginSettingsValuesResponse)
+def get_plugin_settings(
+    plugin_id: str,
+    db: Session = Depends(get_db),
+) -> PluginSettingsValuesResponse:
+    runtime = _ensure_plugin_runtime(plugin_id)
+    schema = runtime.manifest.settings_schema
+    stored = plugin_settings_service.get_settings(db, plugin_id)
+    merged = plugin_settings_service.apply_defaults(schema, stored)
+    return PluginSettingsValuesResponse(values=merged)
+
+
+@router.post("/plugins/{plugin_id}", response_model=PluginSettingsValuesResponse)
+def update_plugin_settings(
+    plugin_id: str,
+    payload: PluginSettingsUpdatePayload,
+    db: Session = Depends(get_db),
+) -> PluginSettingsValuesResponse:
+    runtime = _ensure_plugin_runtime(plugin_id)
+    schema = runtime.manifest.settings_schema
+    try:
+        sanitized, allowed_keys = plugin_settings_service.validate_against_schema(
+            schema, payload.values
+        )
+    except plugin_settings_service.PluginSettingsValidationError as exc:
+        detail = {"error": "invalid_plugin_settings", "message": str(exc)}
+        if exc.field is not None:
+            detail["field"] = exc.field
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+    plugin_settings_service.replace_settings(db, plugin_id, sanitized, allowed_keys)
+    stored = plugin_settings_service.get_settings(db, plugin_id)
+    merged = plugin_settings_service.apply_defaults(schema, stored)
+    return PluginSettingsValuesResponse(values=merged)

--- a/apps/api/app/db/models.py
+++ b/apps/api/app/db/models.py
@@ -127,3 +127,13 @@ class ProviderCredential(Base):
         onupdate=datetime.utcnow,
         server_default=func.now(),
     )
+
+
+class PluginSetting(Base):
+    __tablename__ = "plugin_settings"
+
+    plugin_id: Mapped[str] = mapped_column(String(128), primary_key=True, nullable=False)
+    key: Mapped[str] = mapped_column(String(128), primary_key=True, nullable=False)
+    value_json: Mapped[dict | list | str | int | float | bool | None] = mapped_column(
+        JSON, nullable=True
+    )

--- a/apps/api/app/market/installer.py
+++ b/apps/api/app/market/installer.py
@@ -16,6 +16,8 @@ from app.plugins.loader import (
     register_plugin,
     remove_plugin,
 )
+from app.db.session import session_scope
+from app.services import plugin_settings as plugin_settings_service
 from app.plugins.manifest import PluginManifest
 
 from .registry import PluginIndexItem, verify_sha256
@@ -86,6 +88,9 @@ def uninstall(plugin_id: str) -> None:
         disable_plugin(plugin_id, {})
     except KeyError:
         pass
+
+    with session_scope() as db:
+        plugin_settings_service.delete_settings(db, plugin_id)
 
     remove_plugin(plugin_id)
 

--- a/apps/api/app/plugins/loader.py
+++ b/apps/api/app/plugins/loader.py
@@ -7,9 +7,12 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any
 
 from .manifest import PluginManifest
+from app.db.session import session_scope
+from app.services import plugin_settings as plugin_settings_service
 
 
 PLUGINS_DIR = Path(os.getenv("PLUGINS_DIR", "/app/plugins"))
@@ -24,6 +27,34 @@ class PluginRuntime:
 
 
 _RUNTIMES: dict[str, PluginRuntime] = {}
+
+
+class PluginSettingsStore:
+    """Convenience wrapper for plugin settings CRUD operations."""
+
+    def __init__(self, plugin_id: str) -> None:
+        self._plugin_id = plugin_id
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        with session_scope() as db:
+            value = plugin_settings_service.get_setting(db, self._plugin_id, key)
+        return default if value is None else value
+
+    def all(self) -> dict[str, Any]:
+        with session_scope() as db:
+            return plugin_settings_service.get_settings(db, self._plugin_id)
+
+    def set(self, key: str, value: Any) -> None:
+        with session_scope() as db:
+            plugin_settings_service.set_value(db, self._plugin_id, key, value)
+
+    def set_many(self, values: Mapping[str, Any]) -> None:
+        for key, value in values.items():
+            self.set(key, value)
+
+    def clear(self) -> None:
+        with session_scope() as db:
+            plugin_settings_service.delete_settings(db, self._plugin_id)
 
 
 def _manifest_path(plugin_dir: Path) -> Path:
@@ -64,10 +95,20 @@ def discover_installed() -> list[PluginManifest]:
         with manifest_file.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
         manifest = PluginManifest.model_validate(data)
+        previous = _RUNTIMES.get(manifest.id)
+        if previous is not None:
+            if manifest.settings_schema is None and previous.manifest.settings_schema is not None:
+                manifest.settings_schema = previous.manifest.settings_schema
+            if (
+                manifest.contributes_settings is None
+                and previous.manifest.contributes_settings is not None
+            ):
+                manifest.contributes_settings = previous.manifest.contributes_settings
+        if manifest.contributes_settings is None and manifest.settings_schema is not None:
+            manifest.contributes_settings = True
         manifests.append(manifest)
         site_dir = _site_packages_dir(child)
         instance = import_entry(site_dir, manifest.entry_point)
-        previous = _RUNTIMES.get(manifest.id)
         _RUNTIMES[manifest.id] = PluginRuntime(
             manifest=manifest,
             instance=instance,
@@ -86,27 +127,68 @@ def _get_runtime(plugin_id: str) -> PluginRuntime:
     return runtime
 
 
+def list_plugins() -> list[PluginRuntime]:
+    """Return the runtime metadata for all discovered plugins."""
+
+    discover_installed()
+    return list(_RUNTIMES.values())
+
+
 def register_plugin(manifest: PluginManifest, instance: Any) -> None:
     _RUNTIMES[manifest.id] = PluginRuntime(manifest=manifest, instance=instance)
 
 
-def enable_plugin(plugin_id: str, ctx: dict[str, Any]) -> None:
+def register_settings_panel(plugin_id: str, schema: dict[str, Any]) -> None:
+    runtime = _get_runtime(plugin_id)
+    runtime.manifest.settings_schema = schema
+    runtime.manifest.contributes_settings = True
+
+
+def _prepare_context(plugin_id: str, ctx: dict[str, Any] | None) -> dict[str, Any]:
+    prepared: dict[str, Any] = {}
+    if ctx:
+        prepared.update(ctx)
+
+    store = prepared.get("settings_store")
+    if not isinstance(store, PluginSettingsStore):
+        store = PluginSettingsStore(plugin_id)
+        prepared["settings_store"] = store
+
+    if "settings_get" not in prepared:
+        prepared["settings_get"] = store.get
+    if "settings_set" not in prepared:
+        prepared["settings_set"] = store.set_many
+
+    def _register(target_plugin_id: str, schema: dict[str, Any]) -> None:
+        if target_plugin_id != plugin_id:
+            raise ValueError("Plugin ID mismatch when registering settings panel")
+        register_settings_panel(target_plugin_id, schema)
+
+    if "register_settings_panel" not in prepared:
+        prepared["register_settings_panel"] = _register
+
+    return prepared
+
+
+def enable_plugin(plugin_id: str, ctx: dict[str, Any] | None = None) -> None:
     runtime = _get_runtime(plugin_id)
     if runtime.enabled:
         return
+    prepared_ctx = _prepare_context(plugin_id, ctx)
     hook = getattr(runtime.instance, "on_enable", None)
     if callable(hook):
-        hook(ctx)
+        hook(prepared_ctx)
     runtime.enabled = True
 
 
-def disable_plugin(plugin_id: str, ctx: dict[str, Any]) -> None:
+def disable_plugin(plugin_id: str, ctx: dict[str, Any] | None = None) -> None:
     runtime = _get_runtime(plugin_id)
     if not runtime.enabled:
         return
+    prepared_ctx = _prepare_context(plugin_id, ctx)
     hook = getattr(runtime.instance, "on_disable", None)
     if callable(hook):
-        hook(ctx)
+        hook(prepared_ctx)
     runtime.enabled = False
 
 

--- a/apps/api/app/schemas/settings.py
+++ b/apps/api/app/schemas/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
@@ -32,3 +34,22 @@ class ProviderCredentialsResponse(BaseModel):
     """Envelope listing provider credential configuration."""
 
     providers: list[ProviderCredentialStatus] = Field(default_factory=list)
+
+
+class PluginSettingsSummary(BaseModel):
+    id: str
+    name: str
+    contributes_settings: bool = False
+    settings_schema: dict[str, Any] | None = None
+
+
+class PluginSettingsListResponse(BaseModel):
+    plugins: list[PluginSettingsSummary] = Field(default_factory=list)
+
+
+class PluginSettingsValuesResponse(BaseModel):
+    values: dict[str, Any] = Field(default_factory=dict)
+
+
+class PluginSettingsUpdatePayload(BaseModel):
+    values: dict[str, Any] = Field(default_factory=dict)

--- a/apps/api/app/services/plugin_settings.py
+++ b/apps/api/app/services/plugin_settings.py
@@ -1,0 +1,226 @@
+"""Persistence and validation helpers for plugin settings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.db.models import PluginSetting
+
+
+class PluginSettingsValidationError(ValueError):
+    """Raised when submitted plugin settings fail schema validation."""
+
+    def __init__(self, message: str, field: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+def _extract_types(field_schema: Mapping[str, Any]) -> tuple[set[str], bool]:
+    raw_type = field_schema.get("type")
+    types: set[str] = set()
+    nullable = False
+
+    if isinstance(raw_type, str):
+        if raw_type == "null":
+            nullable = True
+        else:
+            types.add(raw_type)
+    elif isinstance(raw_type, list):
+        for entry in raw_type:
+            if entry == "null":
+                nullable = True
+            elif isinstance(entry, str):
+                types.add(entry)
+
+    # Some schemas may use "password" as a primary type which should behave like string
+    if "password" in types:
+        types.add("string")
+
+    return types, nullable
+
+
+def _coerce_boolean(raw: Any) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise PluginSettingsValidationError("Value must be a boolean")
+
+
+def _validate_field(field: str, field_schema: Mapping[str, Any], raw: Any) -> Any:
+    enum_values = field_schema.get("enum")
+    types, nullable = _extract_types(field_schema)
+
+    if isinstance(enum_values, list) and enum_values:
+        allowed = set(enum_values)
+        if raw is None:
+            if nullable or None in allowed:
+                return None
+            raise PluginSettingsValidationError("Value is required", field=field)
+        if raw not in allowed:
+            raise PluginSettingsValidationError("Value must match one of the allowed options", field=field)
+        return raw
+
+    if raw is None:
+        if nullable:
+            return None
+        raise PluginSettingsValidationError("Value is required", field=field)
+
+    if "boolean" in types:
+        try:
+            return _coerce_boolean(raw)
+        except PluginSettingsValidationError as exc:
+            exc.field = field
+            raise
+
+    if field_schema.get("format") == "password":
+        types.add("string")
+
+    if "string" in types or not types:
+        if isinstance(raw, str):
+            return raw
+        return str(raw)
+
+    raise PluginSettingsValidationError("Unsupported field type", field=field)
+
+
+def validate_against_schema(
+    schema: Mapping[str, Any] | None,
+    values: Mapping[str, Any],
+) -> tuple[dict[str, Any], set[str]]:
+    """Validate ``values`` against ``schema`` returning sanitized data and allowed keys."""
+
+    if not isinstance(values, Mapping):
+        raise PluginSettingsValidationError("Settings values must be an object")
+
+    if not schema:
+        sanitized = {str(key): value for key, value in values.items()}
+        return sanitized, set(sanitized.keys())
+
+    if not isinstance(schema, Mapping):
+        raise PluginSettingsValidationError("Invalid schema definition")
+
+    properties = schema.get("properties") or {}
+    if not isinstance(properties, Mapping):
+        raise PluginSettingsValidationError("Invalid schema definition")
+
+    required = schema.get("required") or []
+    if not isinstance(required, (list, tuple, set)):
+        raise PluginSettingsValidationError("Invalid schema definition")
+
+    allowed_keys = {str(key) for key in properties.keys()}
+    values_dict = {str(key): value for key, value in values.items()}
+
+    for key in values_dict.keys():
+        if key not in allowed_keys:
+            raise PluginSettingsValidationError("Unknown setting key", field=key)
+
+    for key in required:
+        key_str = str(key)
+        if key_str not in values_dict:
+            raise PluginSettingsValidationError("Missing required field", field=key_str)
+
+    sanitized: dict[str, Any] = {}
+    for key, field_schema in properties.items():
+        if key not in values_dict:
+            continue
+        if not isinstance(field_schema, Mapping):
+            raise PluginSettingsValidationError("Invalid field schema", field=key)
+        sanitized[key] = _validate_field(key, field_schema, values_dict[key])
+
+    return sanitized, allowed_keys
+
+
+def apply_defaults(schema: Mapping[str, Any] | None, values: Mapping[str, Any]) -> dict[str, Any]:
+    """Merge schema defaults with stored values without mutating the originals."""
+
+    merged = {str(key): value for key, value in values.items()}
+
+    if not schema or not isinstance(schema, Mapping):
+        return merged
+
+    properties = schema.get("properties") or {}
+    if not isinstance(properties, Mapping):
+        return merged
+
+    for key, field_schema in properties.items():
+        if key in merged:
+            continue
+        if isinstance(field_schema, Mapping) and "default" in field_schema:
+            merged[key] = field_schema["default"]
+
+    return merged
+
+
+def get_settings(db: Session, plugin_id: str) -> dict[str, Any]:
+    result = db.execute(
+        select(PluginSetting).where(PluginSetting.plugin_id == plugin_id)
+    )
+    rows = result.scalars().all()
+    return {row.key: row.value_json for row in rows}
+
+
+def get_setting(db: Session, plugin_id: str, key: str) -> Any:
+    result = db.execute(
+        select(PluginSetting.value_json).where(
+            PluginSetting.plugin_id == plugin_id, PluginSetting.key == key
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def set_value(db: Session, plugin_id: str, key: str, value: Any) -> None:
+    result = db.execute(
+        select(PluginSetting).where(
+            PluginSetting.plugin_id == plugin_id, PluginSetting.key == key
+        )
+    )
+    existing = result.scalar_one_or_none()
+    if existing is None:
+        db.add(PluginSetting(plugin_id=plugin_id, key=key, value_json=value))
+    else:
+        existing.value_json = value
+    db.flush()
+
+
+def replace_settings(
+    db: Session,
+    plugin_id: str,
+    values: Mapping[str, Any],
+    allowed_keys: set[str] | None = None,
+) -> None:
+    result = db.execute(
+        select(PluginSetting).where(PluginSetting.plugin_id == plugin_id)
+    )
+    existing = {row.key: row for row in result.scalars().all()}
+
+    incoming_keys = {str(key) for key in values.keys()}
+
+    for key, value in values.items():
+        record = existing.get(key)
+        if record is None:
+            db.add(PluginSetting(plugin_id=plugin_id, key=key, value_json=value))
+        else:
+            record.value_json = value
+
+    for key, record in existing.items():
+        if key in incoming_keys:
+            continue
+        if allowed_keys is not None and key not in allowed_keys:
+            continue
+        db.delete(record)
+
+    db.flush()
+
+
+def delete_settings(db: Session, plugin_id: str) -> None:
+    db.execute(delete(PluginSetting).where(PluginSetting.plugin_id == plugin_id))
+    db.flush()

--- a/apps/web/src/app/__tests__/SettingsPage.test.tsx
+++ b/apps/web/src/app/__tests__/SettingsPage.test.tsx
@@ -5,9 +5,22 @@ import { renderWithProviders } from '@/app/test-utils';
 import type {
   ProviderSettingMutationVariables,
   ProviderSettingStatus,
+  PluginSettingsSummary,
 } from '@/app/lib/types';
 
-const { providerQueryState, capabilitiesState, mutationState, mutateAsync, toastMock, toastSuccess, toastError } =
+const {
+  providerQueryState,
+  capabilitiesState,
+  mutationState,
+  mutateAsync,
+  toastMock,
+  toastSuccess,
+  toastError,
+  pluginListState,
+  pluginValuesState,
+  pluginMutationState,
+  pluginMutateAsync,
+} =
   vi.hoisted(() => {
     const providerQueryState = {
       data: [] as ProviderSettingStatus[] | undefined,
@@ -35,6 +48,32 @@ const { providerQueryState, capabilitiesState, mutationState, mutateAsync, toast
       return { provider: variables.provider, configured: Boolean(variables.api_key) } as ProviderSettingStatus;
     });
 
+    const pluginListState = {
+      data: [] as PluginSettingsSummary[] | undefined,
+      isLoading: false,
+      isError: false,
+      error: null as Error | null,
+    };
+
+    const pluginValuesState = {
+      data: { values: {} },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null as Error | null,
+    };
+
+    const pluginMutationState = {
+      isPending: false,
+    };
+
+    const pluginMutateAsync = vi.fn(async () => {
+      pluginMutationState.isPending = true;
+      await Promise.resolve();
+      pluginMutationState.isPending = false;
+      return { values: {} };
+    });
+
     const toastSuccess = vi.fn();
     const toastError = vi.fn();
     const toastMock = Object.assign(vi.fn(), {
@@ -42,7 +81,19 @@ const { providerQueryState, capabilitiesState, mutationState, mutateAsync, toast
       error: toastError,
     });
 
-    return { providerQueryState, capabilitiesState, mutationState, mutateAsync, toastMock, toastSuccess, toastError };
+    return {
+      providerQueryState,
+      capabilitiesState,
+      mutationState,
+      mutateAsync,
+      toastMock,
+      toastSuccess,
+      toastError,
+      pluginListState,
+      pluginValuesState,
+      pluginMutationState,
+      pluginMutateAsync,
+    };
   });
 
 vi.mock('sonner', () => ({
@@ -56,6 +107,12 @@ vi.mock('@/app/lib/api', () => ({
     mutateAsync,
     isPending: mutationState.isPending,
     variables: mutationState.variables,
+  }),
+  usePluginSettingsList: () => pluginListState,
+  usePluginSettings: () => pluginValuesState,
+  useUpdatePluginSettings: () => ({
+    mutateAsync: pluginMutateAsync,
+    isPending: pluginMutationState.isPending,
   }),
 }));
 
@@ -71,6 +128,17 @@ describe('SettingsPage services tab', () => {
     providerQueryState.isError = false;
     providerQueryState.error = null;
     providerQueryState.data = [];
+    pluginListState.data = [];
+    pluginListState.isLoading = false;
+    pluginListState.isError = false;
+    pluginListState.error = null;
+    pluginValuesState.data = { values: {} };
+    pluginValuesState.isLoading = false;
+    pluginValuesState.isFetching = false;
+    pluginValuesState.isError = false;
+    pluginValuesState.error = null;
+    pluginMutateAsync.mockClear();
+    pluginMutationState.isPending = false;
   });
 
   it('renders provider guidance links', async () => {

--- a/apps/web/src/app/lib/types.ts
+++ b/apps/web/src/app/lib/types.ts
@@ -212,3 +212,41 @@ export interface ProviderSettingMutationVariables {
 export interface ProviderSettingUpdateRequest {
   api_key: string | null;
 }
+
+export interface PluginSettingFieldSchema {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  enum?: Array<string | number | boolean | null>;
+  format?: string;
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+export interface PluginSettingsSchema {
+  type?: string;
+  title?: string;
+  description?: string;
+  properties?: Record<string, PluginSettingFieldSchema>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+export interface PluginSettingsSummary {
+  id: string;
+  name: string;
+  contributes_settings: boolean;
+  settings_schema?: PluginSettingsSchema | null;
+}
+
+export interface PluginSettingsListResponse {
+  plugins: PluginSettingsSummary[];
+}
+
+export interface PluginSettingsValuesResponse {
+  values: Record<string, unknown>;
+}
+
+export interface PluginSettingsUpdateRequest {
+  values: Record<string, unknown>;
+}

--- a/apps/web/src/app/routes/settings.tsx
+++ b/apps/web/src/app/routes/settings.tsx
@@ -1,14 +1,28 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/ui/tabs';
 import { Switch } from '@/app/components/ui/switch';
 import { Label } from '@/app/components/ui/label';
 import { Input } from '@/app/components/ui/input';
-import { useCapabilities, useProviderSettings, useUpdateProviderSetting } from '@/app/lib/api';
+import {
+  useCapabilities,
+  usePluginSettings,
+  usePluginSettingsList,
+  useProviderSettings,
+  useUpdatePluginSettings,
+  useUpdateProviderSetting,
+} from '@/app/lib/api';
 import { useTheme } from '@/app/components/ThemeProvider';
 import { Skeleton } from '@/app/components/ui/skeleton';
 import { Button } from '@/app/components/ui/button';
 import { toast } from 'sonner';
-import type { MetadataProviderSlug } from '@/app/lib/types';
+import type {
+  MetadataProviderSlug,
+  PluginSettingFieldSchema,
+  PluginSettingsSchema,
+  PluginSettingsSummary,
+} from '@/app/lib/types';
+import { cn } from '@/app/utils/cn';
 
 interface ProviderMeta {
   label: string;
@@ -106,6 +120,102 @@ const PROVIDER_ORDER: MetadataProviderSlug[] = [
   'spotify_client_secret',
 ];
 
+type PluginFieldType = 'string' | 'password' | 'boolean' | 'select';
+
+function getPluginFieldType(schema?: PluginSettingFieldSchema | null): PluginFieldType {
+  if (!schema) {
+    return 'string';
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return 'select';
+  }
+
+  const format = typeof schema.format === 'string' ? schema.format.toLowerCase() : '';
+  const rawType = schema.type;
+  const typeList = Array.isArray(rawType)
+    ? rawType.map((entry) => (typeof entry === 'string' ? entry.toLowerCase() : ''))
+    : typeof rawType === 'string'
+      ? [rawType.toLowerCase()]
+      : [];
+  const normalizedTypes = typeList.filter((entry) => entry && entry !== 'null');
+
+  if (normalizedTypes.includes('boolean')) {
+    return 'boolean';
+  }
+  if (format === 'password' || normalizedTypes.includes('password')) {
+    return 'password';
+  }
+  return 'string';
+}
+
+function normalizePluginValues(
+  schema: PluginSettingsSchema | null | undefined,
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  const properties = schema?.properties ?? {};
+
+  Object.entries(properties).forEach(([key, fieldSchema]) => {
+    const fieldType = getPluginFieldType(fieldSchema);
+    let value = values[key];
+
+    if (value === undefined) {
+      if (fieldSchema && Object.prototype.hasOwnProperty.call(fieldSchema, 'default')) {
+        value = fieldSchema.default;
+      }
+    }
+
+    if (fieldType === 'boolean') {
+      normalized[key] = Boolean(value);
+    } else if (value === undefined || value === null) {
+      normalized[key] = '';
+    } else {
+      normalized[key] = String(value);
+    }
+  });
+
+  return normalized;
+}
+
+function preparePluginSubmitValues(
+  schema: PluginSettingsSchema | null | undefined,
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const prepared: Record<string, unknown> = {};
+  const properties = schema?.properties ?? {};
+
+  Object.entries(properties).forEach(([key, fieldSchema]) => {
+    const fieldType = getPluginFieldType(fieldSchema);
+    const rawValue = values[key];
+
+    if (fieldType === 'boolean') {
+      prepared[key] = Boolean(rawValue);
+    } else if (rawValue === undefined || rawValue === null) {
+      prepared[key] = '';
+    } else if (typeof rawValue === 'string') {
+      prepared[key] = rawValue;
+    } else {
+      prepared[key] = String(rawValue);
+    }
+  });
+
+  return prepared;
+}
+
+function arePluginValuesEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function formatProviderLabel(provider: string): string {
   return provider
     .split(/[-_]/)
@@ -128,6 +238,221 @@ function getProviderMeta(provider: string): ProviderMeta {
   };
 }
 
+interface PluginSettingsCardProps {
+  plugin: PluginSettingsSummary;
+}
+
+function PluginSettingsCard({ plugin }: PluginSettingsCardProps) {
+  const schema = plugin.settings_schema ?? null;
+  const [open, setOpen] = useState(false);
+  const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+  const [baseline, setBaseline] = useState<Record<string, unknown>>({});
+
+  const pluginValuesQuery = usePluginSettings(plugin.id, { enabled: open });
+  const updatePluginSettings = useUpdatePluginSettings(plugin.id);
+
+  useEffect(() => {
+    if (!pluginValuesQuery.data) {
+      return;
+    }
+    const normalized = normalizePluginValues(schema, pluginValuesQuery.data.values ?? {});
+    setFormValues(normalized);
+    setBaseline(normalized);
+  }, [pluginValuesQuery.data, schema]);
+
+  const fieldEntries = useMemo(
+    () => Object.entries(schema?.properties ?? {}),
+    [schema?.properties],
+  );
+  const requiredFields = useMemo(() => new Set(schema?.required ?? []), [schema?.required]);
+  const isDirty = useMemo(() => !arePluginValuesEqual(formValues, baseline), [formValues, baseline]);
+  const isSaving = updatePluginSettings.isPending;
+  const isLoadingValues = pluginValuesQuery.isLoading || pluginValuesQuery.isFetching;
+  const contentId = `${plugin.id}-settings`;
+
+  const handleToggle = () => {
+    setOpen((prev) => !prev);
+  };
+
+  const handleReset = () => {
+    setFormValues(baseline);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const payload = preparePluginSubmitValues(schema, formValues);
+    try {
+      const result = await updatePluginSettings.mutateAsync({ values: payload });
+      const normalized = normalizePluginValues(schema, result.values ?? {});
+      setFormValues(normalized);
+      setBaseline(normalized);
+      toast.success('Settings saved');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save settings.');
+    }
+  };
+
+  const hasFields = fieldEntries.length > 0;
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-border/60 bg-background/60 p-4">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={open}
+        aria-controls={contentId}
+        className="flex w-full items-center justify-between gap-4 text-left"
+      >
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-foreground">{plugin.name}</h3>
+          {schema?.description ? (
+            <p className="text-sm text-muted-foreground">{schema.description}</p>
+          ) : null}
+        </div>
+        <ChevronDown
+          className={cn(
+            'h-5 w-5 shrink-0 text-muted-foreground transition-transform',
+            open ? 'rotate-180' : 'rotate-0',
+          )}
+        />
+      </button>
+      {open ? (
+        <div id={contentId} className="space-y-4">
+          {pluginValuesQuery.isError ? (
+            <p className="text-sm text-destructive">
+              Failed to load settings{pluginValuesQuery.error?.message ? `: ${pluginValuesQuery.error.message}` : '.'}
+            </p>
+          ) : !schema ? (
+            <p className="text-sm text-muted-foreground">
+              This plugin did not provide a settings schema.
+            </p>
+          ) : isLoadingValues ? (
+            <div className="space-y-3">
+              {Array.from({ length: Math.max(1, fieldEntries.length || 3) }).map((_, index) => (
+                <div key={index} className="space-y-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+          ) : !hasFields ? (
+            <p className="text-sm text-muted-foreground">No configurable options are available for this plugin.</p>
+          ) : (
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              {fieldEntries.map(([key, fieldSchema]) => {
+                const fieldType = getPluginFieldType(fieldSchema);
+                const fieldId = `${plugin.id}-${key}`;
+                const label = fieldSchema?.title ?? formatProviderLabel(key);
+                const description =
+                  typeof fieldSchema?.description === 'string' ? fieldSchema.description : undefined;
+                const value = formValues[key];
+                const isRequired = requiredFields.has(key);
+
+                if (fieldType === 'boolean') {
+                  return (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between rounded-xl border border-border/60 bg-background/50 px-4 py-3"
+                    >
+                      <div className="space-y-1">
+                        <Label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+                          {label}
+                        </Label>
+                        {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+                      </div>
+                      <Switch
+                        id={fieldId}
+                        checked={Boolean(value)}
+                        onCheckedChange={(checked) =>
+                          setFormValues((prev) => ({ ...prev, [key]: checked }))
+                        }
+                        disabled={isSaving || isLoadingValues}
+                      />
+                    </div>
+                  );
+                }
+
+                const commonLabel = (
+                  <Label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+                    {label}
+                    {isRequired ? <span className="ml-1 text-destructive">*</span> : null}
+                  </Label>
+                );
+
+                if (fieldType === 'select') {
+                  const options = Array.isArray(fieldSchema?.enum) ? fieldSchema.enum : [];
+                  const selectValue =
+                    typeof value === 'string' ? value : value === undefined || value === null ? '' : String(value);
+
+                  return (
+                    <div key={key} className="space-y-2">
+                      {commonLabel}
+                      {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+                      <select
+                        id={fieldId}
+                        value={selectValue}
+                        onChange={(event) =>
+                          setFormValues((prev) => ({ ...prev, [key]: event.target.value }))
+                        }
+                        disabled={isSaving || isLoadingValues}
+                        className="flex h-10 w-full rounded-md border border-input bg-background/60 px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {!isRequired ? <option value="">Select an option</option> : null}
+                        {options.map((option) => {
+                          const optionValue = option === null ? '' : String(option);
+                          const optionLabel =
+                            typeof option === 'string'
+                              ? option
+                              : option === null
+                                ? 'None'
+                                : String(option);
+                          return (
+                            <option key={optionValue} value={optionValue}>
+                              {optionLabel}
+                            </option>
+                          );
+                        })}
+                      </select>
+                    </div>
+                  );
+                }
+
+                const inputType = fieldType === 'password' ? 'password' : 'text';
+                const inputValue =
+                  typeof value === 'string' ? value : value === undefined || value === null ? '' : String(value);
+
+                return (
+                  <div key={key} className="space-y-2">
+                    {commonLabel}
+                    {description ? <p className="text-xs text-muted-foreground">{description}</p> : null}
+                    <Input
+                      id={fieldId}
+                      type={inputType}
+                      value={inputValue}
+                      onChange={(event) =>
+                        setFormValues((prev) => ({ ...prev, [key]: event.target.value }))
+                      }
+                      disabled={isSaving || isLoadingValues}
+                    />
+                  </div>
+                );
+              })}
+              <div className="flex items-center justify-end gap-2">
+                <Button type="button" variant="ghost" onClick={handleReset} disabled={!isDirty || isSaving}>
+                  Reset
+                </Button>
+                <Button type="submit" disabled={!isDirty || isSaving}>
+                  {isSaving ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function SettingsPage() {
   const { data: capabilities } = useCapabilities();
   const providerQuery = useProviderSettings();
@@ -138,6 +463,14 @@ function SettingsPage() {
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [baselines, setBaselines] = useState<Record<string, string>>({});
   const previousPreviewsRef = useRef<Record<string, string>>({});
+
+  const pluginListQuery = usePluginSettingsList();
+  const pluginsWithSettings = useMemo(() => {
+    if (!pluginListQuery.data) {
+      return [] as PluginSettingsSummary[];
+    }
+    return pluginListQuery.data.filter((plugin) => plugin.contributes_settings);
+  }, [pluginListQuery.data]);
 
   const providers = useMemo(() => {
     if (!providerQuery.data) {
@@ -275,6 +608,7 @@ function SettingsPage() {
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="appearance">Appearance</TabsTrigger>
           <TabsTrigger value="services">Services</TabsTrigger>
+          <TabsTrigger value="plugins">Plugins</TabsTrigger>
         </TabsList>
         <TabsContent value="general" className="space-y-4 rounded-3xl border border-border/60 bg-background/50 p-6">
           <div>
@@ -431,6 +765,46 @@ function SettingsPage() {
             <p className="text-sm text-muted-foreground">No provider settings available.</p>
           )}
           {capabilities ? <p className="text-xs text-muted-foreground">Phelia version {capabilities.version}</p> : null}
+        </TabsContent>
+        <TabsContent value="plugins" className="space-y-4 rounded-3xl border border-border/60 bg-background/50 p-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Plugins</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage plugin-specific settings contributed by installed extensions.
+            </p>
+          </div>
+          {pluginListQuery.isLoading ? (
+            <div className="space-y-4">
+              {Array.from({ length: 2 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="space-y-4 rounded-2xl border border-border/60 bg-background/60 p-4"
+                  aria-busy="true"
+                >
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="h-4 w-48" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-10 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : pluginListQuery.isError ? (
+            <p className="text-sm text-destructive">
+              Failed to load plugin settings{pluginListQuery.error?.message ? `: ${pluginListQuery.error.message}` : '.'}
+            </p>
+          ) : pluginsWithSettings.length > 0 ? (
+            <div className="space-y-4">
+              {pluginsWithSettings.map((plugin) => (
+                <PluginSettingsCard key={plugin.id} plugin={plugin} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No plugins with configurable settings are installed.
+            </p>
+          )}
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary
- add a plugin settings persistence layer and migration for storing per-plugin values
- expose plugin settings CRUD endpoints and loader context helpers for plugins
- render a plugins tab in the web UI with dynamic forms backed by the new API

## Testing
- pytest
- pnpm --dir apps/web test